### PR TITLE
Feat:(#66) 공지사항 다중 삭제를 구현한다.

### DIFF
--- a/gradle/db.gradle
+++ b/gradle/db.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation 'com.oracle.database.jdbc:ojdbc8:19.8.0.0'
-    https://mvnrepository.com/artifact/com.oracle.ojdbc/orai18n
+// https://mvnrepository.com/artifact/com.oracle.ojdbc/orai18n
 //    implementation group: 'com.oracle.ojdbc', name: 'orai18n', version: '19.3.0.0'
     implementation 'org.hibernate:hibernate-core:6.3.1.Final'  // Hibernate 명시적 추가
 //    runtimeOnly 'com.mysql:mysql-connector-j'

--- a/gradle/db.gradle
+++ b/gradle/db.gradle
@@ -1,8 +1,8 @@
 dependencies {
     implementation 'com.oracle.database.jdbc:ojdbc8:19.8.0.0'
-    // https://mvnrepository.com/artifact/com.oracle.ojdbc/orai18n
-    implementation group: 'com.oracle.ojdbc', name: 'orai18n', version: '19.3.0.0'
+    https://mvnrepository.com/artifact/com.oracle.ojdbc/orai18n
+//    implementation group: 'com.oracle.ojdbc', name: 'orai18n', version: '19.3.0.0'
     implementation 'org.hibernate:hibernate-core:6.3.1.Final'  // Hibernate 명시적 추가
-
+//    runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'redis.clients:jedis:4.2.3'
 }

--- a/src/main/java/com/seoulmilk/notice/application/DeleteNoticeService.java
+++ b/src/main/java/com/seoulmilk/notice/application/DeleteNoticeService.java
@@ -10,6 +10,8 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Log4j2
@@ -19,13 +21,12 @@ public class DeleteNoticeService {
 
     @Transactional
     public void delete(CustomUserDetails customUserDetails, DeleteNoticeRequest deleteNoticeRequest) {
-        Notice notice = noticeRepository.findById(deleteNoticeRequest.id())
-                .orElseThrow(NoticeErrorCode.NOT_EXISTS_NOTICE::toException);
-
-        if (!notice.isAuthor(customUserDetails.getId())) {
-            throw NoticeErrorCode.NOT_AN_AUTHOR.toException();
+        List<Notice> notices = noticeRepository.findAllByIds(deleteNoticeRequest.ids());
+        for (Notice notice : notices) {
+            if (!notice.isAuthor(customUserDetails.getId())) {
+                throw NoticeErrorCode.NOT_AN_AUTHOR.toException();
+            }
         }
-
-        noticeRepository.delete(notice);
+        noticeRepository.deleteAll(notices);
     }
 }

--- a/src/main/java/com/seoulmilk/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/com/seoulmilk/notice/domain/repository/NoticeRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface NoticeRepository {
@@ -24,4 +25,8 @@ public interface NoticeRepository {
     Notice updateNotice(UpdateNoticeRequest updateNoticeRequest, String fileUrl);
 
     Page<Notice> findAllByKeyword(Specification<NoticeJpaEntity> spec, Pageable pageable);
+
+    List<Notice> findAllByIds(List<Long> ids);
+
+    void deleteAll(List<Notice> notices);
 }

--- a/src/main/java/com/seoulmilk/notice/dto/request/DeleteNoticeRequest.java
+++ b/src/main/java/com/seoulmilk/notice/dto/request/DeleteNoticeRequest.java
@@ -2,8 +2,10 @@ package com.seoulmilk.notice.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 public record DeleteNoticeRequest(
-        @Schema(description = "공지사항 ID", example = "1")
-        Long id
+        @Schema(description = "삭제할 공지사항 ID", example = "[1, 2, 3]")
+        List<Long> ids
 ) {
 }

--- a/src/main/java/com/seoulmilk/notice/infrastructure/persistence/jpa/repository/NoticeJpaRepository.java
+++ b/src/main/java/com/seoulmilk/notice/infrastructure/persistence/jpa/repository/NoticeJpaRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 
 public interface NoticeJpaRepository extends JpaRepository<NoticeJpaEntity, Long>, JpaSpecificationExecutor<NoticeJpaEntity> {
 
@@ -23,4 +25,6 @@ public interface NoticeJpaRepository extends JpaRepository<NoticeJpaEntity, Long
     @Transactional
     @Query("UPDATE NoticeJpaEntity n SET n.title = :#{#updateNoticeRequest.title}, n.content = :#{#updateNoticeRequest.content} WHERE n.id = :#{#updateNoticeRequest.id}")
     int update(UpdateNoticeRequest updateNoticeRequest);
+
+    List<NoticeJpaEntity> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/seoulmilk/notice/infrastructure/persistence/repository/NoticeRepositoryImpl.java
+++ b/src/main/java/com/seoulmilk/notice/infrastructure/persistence/repository/NoticeRepositoryImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -71,5 +72,20 @@ public class NoticeRepositoryImpl implements NoticeRepository {
     public Page<Notice> findAllByKeyword(Specification<NoticeJpaEntity> spec, Pageable pageable) {
         Page<NoticeJpaEntity> noticesByKeyword = noticeJpaRepository.findAll(spec, pageable);
         return noticesByKeyword.map(noticeMapper::toDomainEntity);
+    }
+
+    @Override
+    public List<Notice> findAllByIds(List<Long> ids) {
+        List<NoticeJpaEntity> noticeJpaEntities = noticeJpaRepository.findAllByIdIn(ids);
+        return noticeJpaEntities.stream()
+                .map(noticeMapper::toDomainEntity)
+                .toList();
+    }
+
+    @Override
+    public void deleteAll(List<Notice> notices) {
+        noticeJpaRepository.deleteAll(notices.stream()
+                .map(noticeMapper::toJpaEntity)
+                .toList());
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 공지사항 다중 삭제 구현
---

## ✏️ 관련 이슈

- Resolves : #66 
---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 공지사항 삭제 기능이 개선되어, 이제 한 번의 요청으로 여러 공지사항을 일괄 삭제할 수 있습니다. 삭제 요청 시 각 공지사항에 대해 사용자의 삭제 권한이 확인되어 보다 안전하게 처리됩니다.
  - 공지사항 ID 목록을 기반으로 여러 공지사항을 조회할 수 있는 기능이 추가되었습니다.
  
- **버그 수정**
  - 특정 라이브러리 의존성이 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->