### PR TITLE
Feat(#78): 검증 재요청시 반환값을 수정한다

### DIFF
--- a/src/main/java/com/seoulmilk/core/configuration/redis/RedisConfig.java
+++ b/src/main/java/com/seoulmilk/core/configuration/redis/RedisConfig.java
@@ -4,19 +4,29 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new JedisConnectionFactory();
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(redisHost, redisPort);
+        return new LettuceConnectionFactory(configuration);
     }
 
     @Bean

--- a/src/main/java/com/seoulmilk/receipt/application/TaxReceiptValidationService.java
+++ b/src/main/java/com/seoulmilk/receipt/application/TaxReceiptValidationService.java
@@ -6,6 +6,8 @@ import com.seoulmilk.emp.domain.repository.EmpRepository;
 import com.seoulmilk.emp.exception.EmpErrorCode;
 import com.seoulmilk.receipt.domain.InValidReceiptRepository;
 import com.seoulmilk.receipt.domain.ValidReceiptRepository;
+import com.seoulmilk.receipt.domain.entity.InValidReceipt;
+import com.seoulmilk.receipt.domain.entity.ValidReceipt;
 import com.seoulmilk.receipt.dto.request.OcrValidationRequest;
 import com.seoulmilk.receipt.dto.request.TaxReceiptValidationRequest;
 import com.seoulmilk.receipt.infrastructure.factory.ReceiptFactory;
@@ -19,10 +21,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -97,7 +96,7 @@ public class TaxReceiptValidationService {
         return taxReceiptValidationProvider.requestAdditionalAuthentication(taxReceiptValidationRequestList);
     }
 
-    public List<TaxReceiptValidationResponse> retrieveValidatedTaxReceiptsWithTransactionId(CustomUserDetails customUserDetails){
+    public Map<String, Object> retrieveValidatedTaxReceiptsWithTransactionId(CustomUserDetails customUserDetails){
         log.info("[retrieveValidatedTaxReceiptsWithTransactionId] 현재 사용자 pk - {}", customUserDetails.getId());
         Emp emp = getEmployee(customUserDetails.getId());
         log.info("[retrieveValidatedTaxReceiptsWithTransactionId] 현재 사용자 정보 - {}", emp.getName());
@@ -112,20 +111,31 @@ public class TaxReceiptValidationService {
         List<TaxReceiptValidationResponse> responses = taxReceiptValidationProvider.retrieveValidatedTaxReceipts(transactionId);
         Collections.reverse(responses);
 
-        saveRecieptData(emp, requestsData, responses);
+        Map<String, Object> responseMap = saveRecieptData(emp, requestsData, responses);
 
-        return responses;
+        return responseMap;
     }
 
-    private void saveRecieptData(Emp emp, List<OcrValidationRequest> requestsData, List<TaxReceiptValidationResponse> responses){
+    private Map<String, Object> saveRecieptData(Emp emp, List<OcrValidationRequest> requestsData, List<TaxReceiptValidationResponse> responses){
+        Boolean flag = false;
+        List<InValidReceipt> responseDataList = new ArrayList<>();
+
         for(int i = 0; i < responses.size(); i++) {
             OcrValidationRequest ocrValidationRequest = requestsData.get(i);
             if(responses.get(i).resAuthenticity().equals("1")){
                 validReceiptRepository.save(ReceiptFactory.validReceiptCreate(emp, ocrValidationRequest));
             }else if(responses.get(i).resAuthenticity().equals("0")){
-                invalidReceiptRepository.save(ReceiptFactory.inValidReceiptCreate(emp, ocrValidationRequest));
+                flag = true;
+                InValidReceipt inValidReceipt = ReceiptFactory.inValidReceiptCreate(emp, ocrValidationRequest);
+                invalidReceiptRepository.save(inValidReceipt);
+                responseDataList.add(inValidReceipt);
             }
         }
+
+        return Map.of(
+                "result", flag,
+                "invalid", responseDataList
+        );
     }
 
     // 파일 업로드 하지 않고 5개 정보로 요청을 보낸경우

--- a/src/main/java/com/seoulmilk/receipt/application/TaxReceiptValidationService.java
+++ b/src/main/java/com/seoulmilk/receipt/application/TaxReceiptValidationService.java
@@ -154,6 +154,9 @@ public class TaxReceiptValidationService {
         Boolean flag = true;
 
         for(int i = 0; i < responses.size(); i++) {
+            if (i >= receiptPks.size()) {
+                throw new IllegalStateException("receiptPks와 responses의 개수가 일치하지 않습니다.");
+            }
             Long pk = receiptPks.get(i);
             if(responses.get(i).resAuthenticity().equals("1")){
                 InValidReceipt inValidReceipt = invalidReceiptRepository.findById(pk)

--- a/src/main/java/com/seoulmilk/receipt/application/TaxReceiptValidationService.java
+++ b/src/main/java/com/seoulmilk/receipt/application/TaxReceiptValidationService.java
@@ -12,6 +12,9 @@ import com.seoulmilk.receipt.dto.request.TaxReceiptValidationRequest;
 import com.seoulmilk.receipt.exception.ReceiptErrorCode;
 import com.seoulmilk.receipt.infrastructure.factory.ReceiptFactory;
 import com.seoulmilk.receipt.infrastructure.factory.TaxReceiptValidationRequestFactory;
+import com.seoulmilk.receipt.infrastructure.persistence.jpa.entity.InValidReceiptJpaEntity;
+import com.seoulmilk.receipt.infrastructure.persistence.jpa.repository.InValidJpaReceiptRepository;
+import com.seoulmilk.receipt.infrastructure.persistence.mapper.InValidReceiptMapper;
 import com.seoulmilk.receipt.infrastructure.service.ReceiptCacheService;
 import com.seoulmilk.receipt.presentation.dto.request.ValidationRequest;
 import com.seoulmilk.receipt.presentation.dto.response.AdditionalAuthResponse;
@@ -32,6 +35,7 @@ public class TaxReceiptValidationService {
     private final ReceiptCacheService receiptCacheService;
     private final InValidReceiptRepository invalidReceiptRepository;
     private final ValidReceiptRepository validReceiptRepository;
+    private final InValidReceiptMapper invalidReceiptMapper;
 
     @KafkaListener(topics = "${kafka.topic}", groupId = "${kafka.group-id}", concurrency = "3", errorHandler = "noRetryErrorHandler")
     public void listen(List<OcrValidationRequest> ocrValidationRequestList) {
@@ -101,7 +105,6 @@ public class TaxReceiptValidationService {
 
     private Boolean saveRecieptData(Emp emp, List<OcrValidationRequest> requestsData, List<TaxReceiptValidationResponse> responses){
         Boolean flag = true;
-
         for(int i = 0; i < responses.size(); i++) {
             OcrValidationRequest ocrValidationRequest = requestsData.get(i);
             if(responses.get(i).resAuthenticity().equals("1")){

--- a/src/main/java/com/seoulmilk/receipt/application/TaxReceiptValidationService.java
+++ b/src/main/java/com/seoulmilk/receipt/application/TaxReceiptValidationService.java
@@ -7,9 +7,9 @@ import com.seoulmilk.emp.exception.EmpErrorCode;
 import com.seoulmilk.receipt.domain.InValidReceiptRepository;
 import com.seoulmilk.receipt.domain.ValidReceiptRepository;
 import com.seoulmilk.receipt.domain.entity.InValidReceipt;
-import com.seoulmilk.receipt.domain.entity.ValidReceipt;
 import com.seoulmilk.receipt.dto.request.OcrValidationRequest;
 import com.seoulmilk.receipt.dto.request.TaxReceiptValidationRequest;
+import com.seoulmilk.receipt.exception.ReceiptErrorCode;
 import com.seoulmilk.receipt.infrastructure.factory.ReceiptFactory;
 import com.seoulmilk.receipt.infrastructure.factory.TaxReceiptValidationRequestFactory;
 import com.seoulmilk.receipt.infrastructure.service.ReceiptCacheService;
@@ -79,6 +79,44 @@ public class TaxReceiptValidationService {
         return TaxReceiptValidationRequestFactory.create(emp, validationRequest, uuid);
     }
 
+    public Boolean retrieveValidatedTaxReceiptsWithTransactionId(CustomUserDetails customUserDetails){
+        log.info("[retrieveValidatedTaxReceiptsWithTransactionId] 현재 사용자 pk - {}", customUserDetails.getId());
+        Emp emp = getEmployee(customUserDetails.getId());
+        log.info("[retrieveValidatedTaxReceiptsWithTransactionId] 현재 사용자 정보 - {}", emp.getName());
+
+        String transactionCacheKey = "transactionId:" + customUserDetails.getId();
+        String transactionId = receiptCacheService.getTransactionIdInRedis(transactionCacheKey);
+        log.info("[retrieveValidatedTaxReceiptsWithTransactionId] 현재 트랜잭션 id - {}", transactionId);
+
+        String dataCacheKey = "requestData:" + customUserDetails.getId();
+        List<OcrValidationRequest> requestsData = receiptCacheService.getOcrValidationRequestDataInRedis(dataCacheKey);
+
+        List<TaxReceiptValidationResponse> responses = taxReceiptValidationProvider.retrieveValidatedTaxReceipts(transactionId);
+        Collections.reverse(responses);
+
+        Boolean success = saveRecieptData(emp, requestsData, responses);
+
+        return success;
+    }
+
+    private Boolean saveRecieptData(Emp emp, List<OcrValidationRequest> requestsData, List<TaxReceiptValidationResponse> responses){
+        Boolean flag = true;
+
+        for(int i = 0; i < responses.size(); i++) {
+            OcrValidationRequest ocrValidationRequest = requestsData.get(i);
+            if(responses.get(i).resAuthenticity().equals("1")){
+                validReceiptRepository.save(ReceiptFactory.validReceiptCreate(emp, ocrValidationRequest));
+            }else if(responses.get(i).resAuthenticity().equals("0")){
+                flag = false;
+                InValidReceipt inValidReceipt = ReceiptFactory.inValidReceiptCreate(emp, ocrValidationRequest);
+                invalidReceiptRepository.save(inValidReceipt);
+            }
+        }
+
+        return flag;
+    }
+
+    // 파일 업로드 하지 않고 5개 정보로 요청을 보낸경우
     public AdditionalAuthResponse requestAdditionalAuthentication(
             CustomUserDetails customUserDetails,
             List<ValidationRequest> requests
@@ -96,57 +134,34 @@ public class TaxReceiptValidationService {
         return taxReceiptValidationProvider.requestAdditionalAuthentication(taxReceiptValidationRequestList);
     }
 
-    public Map<String, Object> retrieveValidatedTaxReceiptsWithTransactionId(CustomUserDetails customUserDetails){
-        log.info("[retrieveValidatedTaxReceiptsWithTransactionId] 현재 사용자 pk - {}", customUserDetails.getId());
-        Emp emp = getEmployee(customUserDetails.getId());
-        log.info("[retrieveValidatedTaxReceiptsWithTransactionId] 현재 사용자 정보 - {}", emp.getName());
-
-        String transactionCacheKey = "transactionId:" + customUserDetails.getId();
-        String transactionId = receiptCacheService.getTransactionIdInRedis(transactionCacheKey);
-        log.info("[retrieveValidatedTaxReceiptsWithTransactionId] 현재 트랜잭션 id - {}", transactionId);
-
-        String dataCacheKey = "requestData:" + customUserDetails.getId();
-        List<OcrValidationRequest> requestsData = receiptCacheService.getOcrValidationRequestDataInRedis(dataCacheKey);
-
-        List<TaxReceiptValidationResponse> responses = taxReceiptValidationProvider.retrieveValidatedTaxReceipts(transactionId);
-        Collections.reverse(responses);
-
-        Map<String, Object> responseMap = saveRecieptData(emp, requestsData, responses);
-
-        return responseMap;
-    }
-
-    private Map<String, Object> saveRecieptData(Emp emp, List<OcrValidationRequest> requestsData, List<TaxReceiptValidationResponse> responses){
-        Boolean flag = false;
-        List<InValidReceipt> responseDataList = new ArrayList<>();
-
-        for(int i = 0; i < responses.size(); i++) {
-            OcrValidationRequest ocrValidationRequest = requestsData.get(i);
-            if(responses.get(i).resAuthenticity().equals("1")){
-                validReceiptRepository.save(ReceiptFactory.validReceiptCreate(emp, ocrValidationRequest));
-            }else if(responses.get(i).resAuthenticity().equals("0")){
-                flag = true;
-                InValidReceipt inValidReceipt = ReceiptFactory.inValidReceiptCreate(emp, ocrValidationRequest);
-                invalidReceiptRepository.save(inValidReceipt);
-                responseDataList.add(inValidReceipt);
-            }
-        }
-
-        return Map.of(
-                "result", flag,
-                "invalid", responseDataList
-        );
-    }
-
-    // 파일 업로드 하지 않고 5개 정보로 요청을 보낸경우
-    public List<TaxReceiptValidationResponse> retrieveValidatedTaxReceipts(
-            Long empPk, List<OcrValidationRequest> requestsData, String transactionId
+    public Boolean retrieveValidatedTaxReceipts(
+            CustomUserDetails customUserDetails, List<Long> receiptPks, String transactionId
     ) {
         List<TaxReceiptValidationResponse> responses =
                 taxReceiptValidationProvider.retrieveValidatedTaxReceipts(transactionId);
 
-        saveRecieptData(getEmployee(empPk), requestsData, responses);
+        Collections.reverse(responses);
 
-        return responses;
+        Boolean success = updateInvalidReceiptData(getEmployee(customUserDetails.getId()), receiptPks, responses);
+
+        return success;
+    }
+
+    public Boolean updateInvalidReceiptData(Emp emp, List<Long> receiptPks, List<TaxReceiptValidationResponse> responses){
+        Boolean flag = true;
+
+        for(int i = 0; i < responses.size(); i++) {
+            Long pk = receiptPks.get(i);
+            if(responses.get(i).resAuthenticity().equals("1")){
+                InValidReceipt inValidReceipt = invalidReceiptRepository.findById(pk)
+                        .orElseThrow(ReceiptErrorCode.NOT_EXIST_RECEIPT::toException);
+                invalidReceiptRepository.deleteById(pk);
+                validReceiptRepository.save(ReceiptFactory.validReceiptCreate(emp, inValidReceipt));
+            }else if(responses.get(i).resAuthenticity().equals("0")){
+                flag = false;
+            }
+        }
+
+        return flag;
     }
 }

--- a/src/main/java/com/seoulmilk/receipt/application/query/TaxReceiptSearchService.java
+++ b/src/main/java/com/seoulmilk/receipt/application/query/TaxReceiptSearchService.java
@@ -6,6 +6,8 @@ import com.seoulmilk.receipt.domain.InValidReceiptRepository;
 import com.seoulmilk.receipt.domain.ValidReceiptRepository;
 import com.seoulmilk.receipt.domain.entity.ValidReceipt;
 import com.seoulmilk.receipt.dto.request.ValidResponseSearchRequest;
+import com.seoulmilk.receipt.infrastructure.persistence.jpa.entity.InValidReceiptJpaEntity;
+import com.seoulmilk.receipt.infrastructure.persistence.jpa.repository.InValidJpaReceiptRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -17,7 +19,7 @@ import java.util.List;
 @Log4j2
 public class TaxReceiptSearchService {
     private final ValidReceiptRepository validReceiptRepository;
-    private final InValidReceiptRepository invalidReceiptRepository;
+    private final InValidJpaReceiptRepository inValidJpaReceiptRepository;
 
     public List<ValidReceipt> findAllValidReceipt(
             CustomUserDetails customUserDetails,
@@ -30,5 +32,9 @@ public class TaxReceiptSearchService {
             log.info("[findAllValidReceipt] 현재 사용자 - 사원");
             return validReceiptRepository.findAllBySpecification(customUserDetails, keywords);
         }
+    }
+
+    public List<InValidReceiptJpaEntity> findByUserId(String userId){
+        return inValidJpaReceiptRepository.findAllByEmployeeId(userId);
     }
 }

--- a/src/main/java/com/seoulmilk/receipt/domain/InValidReceiptRepository.java
+++ b/src/main/java/com/seoulmilk/receipt/domain/InValidReceiptRepository.java
@@ -1,6 +1,7 @@
 package com.seoulmilk.receipt.domain;
 
 import com.seoulmilk.receipt.domain.entity.InValidReceipt;
+import com.seoulmilk.receipt.infrastructure.persistence.jpa.entity.InValidReceiptJpaEntity;
 import jakarta.transaction.Transactional;
 
 import java.util.List;

--- a/src/main/java/com/seoulmilk/receipt/domain/InValidReceiptRepository.java
+++ b/src/main/java/com/seoulmilk/receipt/domain/InValidReceiptRepository.java
@@ -8,7 +8,8 @@ import java.util.Optional;
 
 public interface InValidReceiptRepository {
     InValidReceipt save(InValidReceipt validReceipt);
-    Optional<InValidReceipt> findById(String issueId);
+    Optional<InValidReceipt> findById(Long pk);
     void deleteAll();
+    void deleteById(Long pk);
     void deleteByIds(List<Long> pk);
 }

--- a/src/main/java/com/seoulmilk/receipt/infrastructure/factory/ReceiptFactory.java
+++ b/src/main/java/com/seoulmilk/receipt/infrastructure/factory/ReceiptFactory.java
@@ -32,6 +32,29 @@ public class ReceiptFactory {
         );
     }
 
+    public static ValidReceipt validReceiptCreate(Emp emp, InValidReceipt inValidReceipt){
+        return ValidReceipt.create(
+                emp.getEmployeeId(),
+                inValidReceipt.getArap(),
+                inValidReceipt.getIssueId(),
+                inValidReceipt.getIssueDate(),
+                inValidReceipt.getSuId(),
+                inValidReceipt.getSuName(),
+                inValidReceipt.getIpId(),
+                inValidReceipt.getIpName(),
+                getChargeTotal(inValidReceipt.getGrandTotal(), inValidReceipt.getTaxTotal()),
+                inValidReceipt.getTaxTotal(),
+                inValidReceipt.getGrandTotal(),
+                inValidReceipt.getErdat(),
+                inValidReceipt.getErzet(),
+                inValidReceipt.getFileUrl()
+        );
+    }
+
+    private static Integer getChargeTotal(Integer grandTotal, Integer taxTotal) {
+        return grandTotal - taxTotal;
+    }
+
     public static InValidReceipt inValidReceiptCreate(Emp emp, OcrValidationRequest ocrValidationRequest){
         String erdat = getDateFormat("yyyy-MM-dd");
         String erzet = getDateFormat("HH:mm:ss");

--- a/src/main/java/com/seoulmilk/receipt/infrastructure/persistence/jpa/repository/InValidJpaReceiptRepository.java
+++ b/src/main/java/com/seoulmilk/receipt/infrastructure/persistence/jpa/repository/InValidJpaReceiptRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 public interface InValidJpaReceiptRepository extends JpaRepository<InValidReceiptJpaEntity, Long> {
     Optional<InValidReceiptJpaEntity> findByIssueId(String issueId);
-
+    List<InValidReceiptJpaEntity> findAllByEmployeeId(String employeeId);
     void deleteAllByIdIn(List<Long> pk);
 }

--- a/src/main/java/com/seoulmilk/receipt/infrastructure/repository/InValidReceiptRepositoryImpl.java
+++ b/src/main/java/com/seoulmilk/receipt/infrastructure/repository/InValidReceiptRepositoryImpl.java
@@ -29,13 +29,18 @@ public class InValidReceiptRepositoryImpl implements InValidReceiptRepository {
     }
 
     @Override
-    public Optional<InValidReceipt> findById(String issueId) {
-        return inValidJpaReceiptRepository.findByIssueId(issueId).map(invalidReceiptMapper::toDomainEntity);
+    public Optional<InValidReceipt> findById(Long pk) {
+        return inValidJpaReceiptRepository.findById(pk).map(invalidReceiptMapper::toDomainEntity);
     }
 
     @Override
     public void deleteAll() {
         inValidJpaReceiptRepository.deleteAll();
+    }
+
+    @Override
+    public void deleteById(Long pk) {
+        inValidJpaReceiptRepository.deleteById(pk);
     }
 
     @Override

--- a/src/main/java/com/seoulmilk/receipt/presentation/controller/crud/TaxReceiptSearchController.java
+++ b/src/main/java/com/seoulmilk/receipt/presentation/controller/crud/TaxReceiptSearchController.java
@@ -6,15 +6,13 @@ import com.seoulmilk.emp.domain.value.Role;
 import com.seoulmilk.receipt.application.query.TaxReceiptSearchService;
 import com.seoulmilk.receipt.domain.entity.ValidReceipt;
 import com.seoulmilk.receipt.dto.request.ValidResponseSearchRequest;
+import com.seoulmilk.receipt.infrastructure.persistence.jpa.entity.InValidReceiptJpaEntity;
 import com.seoulmilk.receipt.presentation.swagger.TaxReceiptSearchSwagger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -38,6 +36,16 @@ public class TaxReceiptSearchController implements TaxReceiptSearchSwagger {
 
         return ResponseEntity.ok(
                 new RestResponse<>(validReceipts)
+        );
+    }
+
+    @Override
+    @GetMapping("/invalid/search")
+    public ResponseEntity<RestResponse<List<InValidReceiptJpaEntity>>> getInvalidReceipts(CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(
+                new RestResponse<>(
+                        taxReceiptSearchService.findByUserId(customUserDetails.getEmployeeId())
+                )
         );
     }
 }

--- a/src/main/java/com/seoulmilk/receipt/presentation/controller/validation/TaxReceiptValidationController.java
+++ b/src/main/java/com/seoulmilk/receipt/presentation/controller/validation/TaxReceiptValidationController.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/v1/receipt")
@@ -55,7 +56,7 @@ public class TaxReceiptValidationController implements TaxReceiptValidateSwagger
 
     @Override
     @PostMapping("/upload/addition")
-    public ResponseEntity<RestResponse<List<TaxReceiptValidationResponse>>> uploadAdditionAuthController(
+    public ResponseEntity<RestResponse<Map<String, Object>>> uploadAdditionAuthController(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){

--- a/src/main/java/com/seoulmilk/receipt/presentation/controller/validation/TaxReceiptValidationController.java
+++ b/src/main/java/com/seoulmilk/receipt/presentation/controller/validation/TaxReceiptValidationController.java
@@ -42,21 +42,23 @@ public class TaxReceiptValidationController implements TaxReceiptValidateSwagger
 
     @Override
     @PostMapping("/addition")
-    public ResponseEntity<RestResponse<List<TaxReceiptValidationResponse>>> multipleAdditionAuthController(
+    public ResponseEntity<RestResponse<Boolean>> multipleAdditionAuthController(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam String transactionId,
-            @RequestBody List<OcrValidationRequest> requests
+            @RequestBody List<Long> inValidReceiptPks
     ){
         log.info("[multipleAdditionAuthController] 컨트롤러 작동");
         return ResponseEntity.ok(
-                new RestResponse<>(taxReceiptValidationService.retrieveValidatedTaxReceipts(customUserDetails.getId(), requests, transactionId))
+                new RestResponse<>(taxReceiptValidationService.retrieveValidatedTaxReceipts(
+                        customUserDetails, inValidReceiptPks, transactionId)
+                )
         );
     }
 
     @Override
     @PostMapping("/upload/addition")
-    public ResponseEntity<RestResponse<Map<String, Object>>> uploadAdditionAuthController(
+    public ResponseEntity<RestResponse<Boolean>> uploadAdditionAuthController(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){

--- a/src/main/java/com/seoulmilk/receipt/presentation/swagger/TaxReceiptSearchSwagger.java
+++ b/src/main/java/com/seoulmilk/receipt/presentation/swagger/TaxReceiptSearchSwagger.java
@@ -4,6 +4,7 @@ import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
 import com.seoulmilk.core.presentation.RestResponse;
 import com.seoulmilk.receipt.domain.entity.ValidReceipt;
 import com.seoulmilk.receipt.dto.request.ValidResponseSearchRequest;
+import com.seoulmilk.receipt.infrastructure.persistence.jpa.entity.InValidReceiptJpaEntity;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -23,5 +24,15 @@ public interface TaxReceiptSearchSwagger {
     ResponseEntity<RestResponse<List<ValidReceipt>>> getValidReceipts(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody ValidResponseSearchRequest request
+    );
+
+
+    @Operation(
+            summary = "본인이 만든 불일치 세금계산서 전체 조회 API",
+            description = "본인의 사번을 통해 본인이 요청한 영수증 중 불일치 세금계산서 정보를 불러옵니다.",
+            operationId = "/v1/receipt/search"
+    )
+    ResponseEntity<RestResponse<List<InValidReceiptJpaEntity>>> getInvalidReceipts(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     );
 }

--- a/src/main/java/com/seoulmilk/receipt/presentation/swagger/TaxReceiptSearchSwagger.java
+++ b/src/main/java/com/seoulmilk/receipt/presentation/swagger/TaxReceiptSearchSwagger.java
@@ -30,7 +30,7 @@ public interface TaxReceiptSearchSwagger {
     @Operation(
             summary = "본인이 만든 불일치 세금계산서 전체 조회 API",
             description = "본인의 사번을 통해 본인이 요청한 영수증 중 불일치 세금계산서 정보를 불러옵니다.",
-            operationId = "/v1/receipt/search"
+            operationId = "/v1/receipt/invalid/search"
     )
     ResponseEntity<RestResponse<List<InValidReceiptJpaEntity>>> getInvalidReceipts(
             @AuthenticationPrincipal CustomUserDetails customUserDetails

--- a/src/main/java/com/seoulmilk/receipt/presentation/swagger/TaxReceiptValidateSwagger.java
+++ b/src/main/java/com/seoulmilk/receipt/presentation/swagger/TaxReceiptValidateSwagger.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
+import java.util.Map;
 
 @Tag(name = "Valid", description = "세금계산서 검증 프로세스")
 public interface TaxReceiptValidateSwagger {
@@ -57,7 +58,7 @@ public interface TaxReceiptValidateSwagger {
             operationId = "/v1/upload/addition"
     )
     @ApiErrorCode({GlobalErrorCode.class, AuthenticationErrorCode.class, ReceiptErrorCode.class})
-    ResponseEntity<RestResponse<List<TaxReceiptValidationResponse>>> uploadAdditionAuthController(
+    ResponseEntity<RestResponse<Map<String,Object>>> uploadAdditionAuthController(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     );

--- a/src/main/java/com/seoulmilk/receipt/presentation/swagger/TaxReceiptValidateSwagger.java
+++ b/src/main/java/com/seoulmilk/receipt/presentation/swagger/TaxReceiptValidateSwagger.java
@@ -44,11 +44,11 @@ public interface TaxReceiptValidateSwagger {
             operationId = "/v1/receipt/addition"
     )
     @ApiErrorCode({GlobalErrorCode.class, AuthenticationErrorCode.class, ReceiptErrorCode.class})
-    ResponseEntity<RestResponse<List<TaxReceiptValidationResponse>>> multipleAdditionAuthController(
+    ResponseEntity<RestResponse<Boolean>> multipleAdditionAuthController(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam String transactionId,
-            @RequestBody List<OcrValidationRequest> requests
+            @RequestBody List<Long> receiptPks
     );
 
     @Operation(
@@ -58,7 +58,7 @@ public interface TaxReceiptValidateSwagger {
             operationId = "/v1/upload/addition"
     )
     @ApiErrorCode({GlobalErrorCode.class, AuthenticationErrorCode.class, ReceiptErrorCode.class})
-    ResponseEntity<RestResponse<Map<String,Object>>> uploadAdditionAuthController(
+    ResponseEntity<RestResponse<Boolean>> uploadAdditionAuthController(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     );


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 업로드 이후 검증 완료시 반환값을 간소화 했습니다(true는 전체 검증 성공, false는 하나라도 실패시 나옴)
- 재요청시에도 마찬가지로 구성했습니다.
- 업로드 시에는 각각의 DB에 값이 저장되도록 했고, 검증 재요청 시에는 PK값을 활용하여 이 데이터가 검증되면 Valid테이블로, 아닌 경우 그대로 table에 남도록 했습니다.
- 불일치 정보 찾는 페이지에서 사용할 수 있도록 사번을 활용하여 불일치 세금계산서의 정보를 찾을 수 있는 API를 구현 했습니다.
![image](https://github.com/user-attachments/assets/15593ca9-f9f5-4de5-aeac-277eac46b2b1)
![image](https://github.com/user-attachments/assets/c582f347-2509-43e0-acea-ff8d3b83e023)


---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

ex)
#78 
---

## 🎸 기타 사항 or 추가 코멘트
- 추가 오류 발생시 수정하도록 하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 사용자 ID 기준 무효 영수증 조회 엔드포인트 추가: 개인별 무효 영수증 목록을 쉽게 확인할 수 있습니다.
  - 간소화된 검증 결과 제공: 인증 및 검증 과정이 개선되어 성공 여부 정보가 명확하게 전달됩니다.

- **Refactor**
  - 영수증 처리 로직 재구성: 불필요한 상세 데이터 대신 단순화된 결과 반환 방식으로 효율성이 향상되었습니다.
  - API 문서 업데이트: 최신 기능이 반영되도록 문서가 보완되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->