### PR TITLE
Feat:(#79) 관리자의 직원 삭제 API를 구현한다.

### DIFF
--- a/src/main/java/com/seoulmilk/auth/presentation/dto/response/LoginResponse.java
+++ b/src/main/java/com/seoulmilk/auth/presentation/dto/response/LoginResponse.java
@@ -24,11 +24,14 @@ public record LoginResponse(
             @Schema(description = "이메일", example = "test@test.com")
             String email,
 
+            @Schema(description = "생년월일", example = "1990-01-01")
+            String birthday,
+
             @Schema(description = "사용자 권한", example = "ADMIN")
             Role role
     ) {
         public static UserInfo from(Emp employee) {
-            return new UserInfo(employee.getEmployeeId(), employee.getName(), employee.getPhoneNumber(), employee.getEmail(), employee.getRole());
+            return new UserInfo(employee.getEmployeeId(), employee.getName(), employee.getPhoneNumber(), employee.getEmail(), employee.getBirthday(), employee.getRole());
         }
     }
 

--- a/src/main/java/com/seoulmilk/core/exception/error/GlobalErrorCode.java
+++ b/src/main/java/com/seoulmilk/core/exception/error/GlobalErrorCode.java
@@ -11,7 +11,8 @@ public enum GlobalErrorCode implements BaseErrorCode<RuntimeException> {
     ALREADY_PROCESS_STARTED(HttpStatus.BAD_REQUEST, "이미 처리중인 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다."),
     INVALID_FILE(HttpStatus.BAD_REQUEST, "유효하지 않은 파일입니다."),
-    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "써드파티 저장소에 파일 업로드 중 오류가 발생했습니다.");
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "써드파티 저장소에 파일 업로드 중 오류가 발생했습니다."),
+    NOT_EXIST_HOMETAX(HttpStatus.NOT_FOUND, "존재하지 않는 홈택스입니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/com/seoulmilk/emp/application/CreateEmpService.java
+++ b/src/main/java/com/seoulmilk/emp/application/CreateEmpService.java
@@ -1,0 +1,48 @@
+package com.seoulmilk.emp.application;
+
+import com.seoulmilk.auth.application.PasswordHashingService;
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.emp.domain.entity.Emp;
+import com.seoulmilk.emp.domain.repository.EmpRepository;
+import com.seoulmilk.emp.domain.value.*;
+import com.seoulmilk.emp.dto.request.GrantPrivilegeRequest;
+import com.seoulmilk.emp.dto.response.CreateEmpResponse;
+import com.seoulmilk.emp.dto.response.GrantPrivilegeResponse;
+import com.seoulmilk.emp.exception.AdminErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class CreateEmpService {
+    private final EmpRepository empRepository;
+    private final PasswordHashingService passwordHashingService;
+
+    @Transactional
+    public CreateEmpResponse create(CustomUserDetails customUserDetails, GrantPrivilegeRequest grantPrivilegeRequest) {
+        if (customUserDetails.getRole() != Role.ADMIN) {
+            log.error("[CreateEmpService.create] 관리자만 사원을 생성할 수 있습니다. 접근 유저 PK: {}", customUserDetails.getId());
+            throw AdminErrorCode.NOT_ADMIN_EXCEPTION.toException();
+        }
+
+        Emp createdEmp = Emp.create(
+                grantPrivilegeRequest.name(),
+                grantPrivilegeRequest.employeeId(),
+                "testEmail@test.com",
+                Role.EMPLOYEE,
+                "01012345678",
+                Telecom.KT,
+                "19900101",
+                HashedPassword.of(passwordHashingService.hash(Password.from("12345678")).getValue()),
+                HomeTax.KB_MOBILE
+        );
+
+        empRepository.save(createdEmp);
+        empRepository.grantPrivilege(createdEmp);
+        return CreateEmpResponse.of(createdEmp);
+    }
+
+}

--- a/src/main/java/com/seoulmilk/emp/application/DeleteEmpService.java
+++ b/src/main/java/com/seoulmilk/emp/application/DeleteEmpService.java
@@ -1,0 +1,40 @@
+package com.seoulmilk.emp.application;
+
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.emp.domain.entity.Emp;
+import com.seoulmilk.emp.domain.repository.EmpRepository;
+import com.seoulmilk.emp.domain.value.Role;
+import com.seoulmilk.emp.dto.request.DeleteEmpsRequest;
+import com.seoulmilk.emp.dto.response.DeleteEmpResponse;
+import com.seoulmilk.emp.exception.AdminErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class DeleteEmpService {
+
+    private final EmpRepository empRepository;
+
+    @Transactional
+    public DeleteEmpResponse delete(
+            CustomUserDetails customUserDetails,
+            DeleteEmpsRequest deleteEmpsRequest
+    ) {
+        if (customUserDetails.getRole() != Role.ADMIN) {
+            log.error("[DeleteEmpService.delete] 관리자만 사원을 삭제할 수 있습니다. 접근 유저 PK: {}", customUserDetails.getId());
+            throw AdminErrorCode.NOT_ADMIN_EXCEPTION.toException();
+        }
+        List<Emp> emps = empRepository.findAllByIds(deleteEmpsRequest.ids());
+        empRepository.deleteAll(emps);
+        return DeleteEmpResponse.of(
+                true,
+                "회원 삭제 성공"
+        );
+    }
+}

--- a/src/main/java/com/seoulmilk/emp/application/DeleteEmpService.java
+++ b/src/main/java/com/seoulmilk/emp/application/DeleteEmpService.java
@@ -31,6 +31,12 @@ public class DeleteEmpService {
             throw AdminErrorCode.NOT_ADMIN_EXCEPTION.toException();
         }
         List<Emp> emps = empRepository.findAllByIds(deleteEmpsRequest.ids());
+
+        if (emps.size() != deleteEmpsRequest.ids().size()) {
+            log.error("[DeleteEmpService.delete] 삭제할 수 없는 회원이 포함되어 있습니다. 삭제할 수 없는 회원 PK: {}", deleteEmpsRequest.ids());
+            throw AdminErrorCode.EMP_NOT_FOUND.toException();
+        }
+
         empRepository.deleteAll(emps);
         return DeleteEmpResponse.of(
                 true,

--- a/src/main/java/com/seoulmilk/emp/application/ReadEmpsService.java
+++ b/src/main/java/com/seoulmilk/emp/application/ReadEmpsService.java
@@ -1,0 +1,48 @@
+package com.seoulmilk.emp.application;
+
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.emp.domain.entity.Emp;
+import com.seoulmilk.emp.domain.repository.EmpRepository;
+import com.seoulmilk.emp.domain.value.Role;
+import com.seoulmilk.emp.dto.response.FilteredEmpResponse;
+import com.seoulmilk.emp.dto.response.ReadEmpResponse;
+import com.seoulmilk.emp.dto.response.ReadEmpsResponse;
+import com.seoulmilk.emp.exception.AdminErrorCode;
+import com.seoulmilk.emp.exception.EmpErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class ReadEmpsService {
+    private final EmpRepository empRepository;
+
+    public ReadEmpsResponse read(CustomUserDetails customUserDetails) {
+        if (customUserDetails.getRole() != Role.ADMIN) {
+            log.error("[ReadEmpsService.read] 관리자만 사원 목록을 조회할 수 있습니다. 접근 유저 PK: {}", customUserDetails.getId());
+            throw AdminErrorCode.NOT_ADMIN_EXCEPTION.toException();
+        }
+        List<FilteredEmpResponse> allEmps = empRepository.findAllWithNeededInfo();
+
+        return ReadEmpsResponse.of(allEmps);
+    }
+
+    public ReadEmpResponse readEmpByName(
+            CustomUserDetails customUserDetails,
+            String name
+    ) {
+        if (customUserDetails.getRole() != Role.ADMIN) {
+            log.error("[ReadEmpsService.readOneEmp] 관리자만 사원을 조회할 수 있습니다. 접근 유저 PK: {}", customUserDetails.getId());
+            throw AdminErrorCode.NOT_ADMIN_EXCEPTION.toException();
+        }
+        Emp emp = empRepository.findByEmployeeName(name).orElseThrow(
+                EmpErrorCode.NOT_EXIST_EMPLOYEE::toException
+        );
+
+        return ReadEmpResponse.of(emp);
+    }
+}

--- a/src/main/java/com/seoulmilk/emp/application/UpdateValidationInfoService.java
+++ b/src/main/java/com/seoulmilk/emp/application/UpdateValidationInfoService.java
@@ -1,0 +1,33 @@
+package com.seoulmilk.emp.application;
+
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.emp.domain.repository.EmpRepository;
+import com.seoulmilk.emp.domain.value.HomeTax;
+import com.seoulmilk.emp.dto.request.UpdateHometaxInfoRequest;
+import com.seoulmilk.emp.dto.response.UpdateHometaxInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateValidationInfoService {
+    private final EmpRepository empRepository;
+
+    @Transactional
+    public UpdateHometaxInfoResponse updateHometaxInfo(
+            CustomUserDetails customUserDetails,
+            UpdateHometaxInfoRequest updateHometaxInfoRequest
+    ) {
+        String homeTax = HomeTax.valueOf(updateHometaxInfoRequest.homeTaxNum()).name();
+
+        empRepository.updateHometaxInfo(
+                customUserDetails.getId(),
+                homeTax);
+
+        return UpdateHometaxInfoResponse.of(
+                true,
+                "홈택스 정보가 성공적으로 업데이트 되었습니다."
+        );
+    }
+}

--- a/src/main/java/com/seoulmilk/emp/domain/repository/EmpRepository.java
+++ b/src/main/java/com/seoulmilk/emp/domain/repository/EmpRepository.java
@@ -1,17 +1,34 @@
 package com.seoulmilk.emp.domain.repository;
 
 import com.seoulmilk.emp.domain.entity.Emp;
+import com.seoulmilk.emp.dto.response.FilteredEmpResponse;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface EmpRepository {
     Emp save(Emp emp);
+
     Optional<Emp> findById(Long id);
+
     Optional<Emp> findByEmployeeId(String employeeId);
+
     Optional<Emp> findByEmployeeName(String employeeName);
-    void deleteAll();
+
+    void deleteAll(List<Emp> emps);
+
     void updatePassword(Long id, String newPassword);
+
     List<Emp> findAllByName(String employeeName);
+
     void grantPrivilege(Emp emp);
+
+    List<Emp> findAllByIds(List<Long> ids);
+
+    List<FilteredEmpResponse> findAllWithNeededInfo();
+
+    List<Emp> findAllOrderByIdDesc(Pageable pageable);
+
+    void updateHometaxInfo(Long empPk, String hometaxName);
 }

--- a/src/main/java/com/seoulmilk/emp/domain/value/HomeTax.java
+++ b/src/main/java/com/seoulmilk/emp/domain/value/HomeTax.java
@@ -1,5 +1,6 @@
 package com.seoulmilk.emp.domain.value;
 
+import com.seoulmilk.core.exception.error.GlobalErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -25,4 +26,14 @@ public enum HomeTax {
     BANK_SALAD("9");
 
     private final String value;
+
+    public static HomeTax fromValue(String value) {
+        for (HomeTax homeTax : values()) {
+            if (homeTax.value.equals(value)) {
+                return homeTax;
+            }
+        }
+        throw GlobalErrorCode.NOT_EXIST_HOMETAX.toException();
+    }
+
 }

--- a/src/main/java/com/seoulmilk/emp/dto/request/DeleteEmpsRequest.java
+++ b/src/main/java/com/seoulmilk/emp/dto/request/DeleteEmpsRequest.java
@@ -1,0 +1,8 @@
+package com.seoulmilk.emp.dto.request;
+
+import java.util.List;
+
+public record DeleteEmpsRequest(
+        List<Long> ids
+) {
+}

--- a/src/main/java/com/seoulmilk/emp/dto/request/UpdateHometaxInfoRequest.java
+++ b/src/main/java/com/seoulmilk/emp/dto/request/UpdateHometaxInfoRequest.java
@@ -1,0 +1,9 @@
+package com.seoulmilk.emp.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UpdateHometaxInfoRequest(
+        @Schema(name = "홈택스 번호", example = "KAKAO : 1, PAYCO : 2, SAMSUMG_PASS : 3, KB_MOBILE : 4, PASS : 5, NAVER : 6, SHINHAN : 7, TOSS : 8, BANK_SALAD : 9")
+        String homeTaxNum
+) {
+}

--- a/src/main/java/com/seoulmilk/emp/dto/request/UpdateHometaxInfoRequest.java
+++ b/src/main/java/com/seoulmilk/emp/dto/request/UpdateHometaxInfoRequest.java
@@ -1,14 +1,12 @@
 package com.seoulmilk.emp.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public record UpdateHometaxInfoRequest(
         @NotNull(message = "홈택스 번호를 입력해주세요.")
-        @Min(value = 1, message = "홈택스 번호는 1부터 9 사이입니다.")
-        @Max(value = 9, message = "홈택스 번호는 1부터 9 사이입니다.")
+        @Pattern(regexp = "^[1-9]$", message = "홈택스 번호는 1부터 9 사이입니다.")
         @Schema(name = "홈택스 번호", example = "KAKAO : 1, PAYCO : 2, SAMSUMG_PASS : 3, KB_MOBILE : 4, PASS : 5, NAVER : 6, SHINHAN : 7, TOSS : 8, BANK_SALAD : 9")
         String homeTaxNum
 ) {

--- a/src/main/java/com/seoulmilk/emp/dto/request/UpdateHometaxInfoRequest.java
+++ b/src/main/java/com/seoulmilk/emp/dto/request/UpdateHometaxInfoRequest.java
@@ -1,8 +1,14 @@
 package com.seoulmilk.emp.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 public record UpdateHometaxInfoRequest(
+        @NotNull(message = "홈택스 번호를 입력해주세요.")
+        @Min(value = 1, message = "홈택스 번호는 1부터 9 사이입니다.")
+        @Max(value = 9, message = "홈택스 번호는 1부터 9 사이입니다.")
         @Schema(name = "홈택스 번호", example = "KAKAO : 1, PAYCO : 2, SAMSUMG_PASS : 3, KB_MOBILE : 4, PASS : 5, NAVER : 6, SHINHAN : 7, TOSS : 8, BANK_SALAD : 9")
         String homeTaxNum
 ) {

--- a/src/main/java/com/seoulmilk/emp/dto/response/CreateEmpResponse.java
+++ b/src/main/java/com/seoulmilk/emp/dto/response/CreateEmpResponse.java
@@ -1,0 +1,25 @@
+package com.seoulmilk.emp.dto.response;
+
+import com.seoulmilk.emp.domain.entity.Emp;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreateEmpResponse(
+        @Schema(
+                name = "employeeId",
+                example = "1234567890",
+                description = "사원번호"
+        )
+        String employeeId,
+
+        @Schema(
+                name = "name",
+                example = "홍길동",
+                description = "이름"
+        )
+        String name
+) {
+    public static CreateEmpResponse of(Emp emp) {
+        return new CreateEmpResponse(emp.getEmployeeId(), emp.getName());
+    }
+
+}

--- a/src/main/java/com/seoulmilk/emp/dto/response/DeleteEmpResponse.java
+++ b/src/main/java/com/seoulmilk/emp/dto/response/DeleteEmpResponse.java
@@ -1,0 +1,10 @@
+package com.seoulmilk.emp.dto.response;
+
+public record DeleteEmpResponse(
+        Boolean success,
+        String message
+) {
+    public static DeleteEmpResponse of(Boolean success, String message) {
+        return new DeleteEmpResponse(success, message);
+    }
+}

--- a/src/main/java/com/seoulmilk/emp/dto/response/FilteredEmpResponse.java
+++ b/src/main/java/com/seoulmilk/emp/dto/response/FilteredEmpResponse.java
@@ -1,0 +1,11 @@
+package com.seoulmilk.emp.dto.response;
+
+import com.seoulmilk.emp.domain.value.Role;
+
+public record FilteredEmpResponse(
+        Long id,
+        String name,
+        String employeeId,
+        Role role
+) {
+}

--- a/src/main/java/com/seoulmilk/emp/dto/response/ReadEmpResponse.java
+++ b/src/main/java/com/seoulmilk/emp/dto/response/ReadEmpResponse.java
@@ -1,0 +1,54 @@
+package com.seoulmilk.emp.dto.response;
+
+import com.seoulmilk.emp.domain.entity.Emp;
+import com.seoulmilk.emp.domain.value.HomeTax;
+import com.seoulmilk.emp.domain.value.Role;
+import com.seoulmilk.emp.domain.value.Telecom;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReadEmpResponse(
+        @Schema(description = "사원 PK")
+        Long id,
+
+        @Schema(description = "사원 번호")
+        String employeeId,
+
+        @Schema(description = "사원 이름")
+        String name,
+
+        @Schema(description = "사원 이메일")
+        String email,
+
+        @Schema(description = "사원 직급")
+        Role role,
+
+        @Schema(description = "사원 전화번호")
+        String phoneNumber,
+
+        @Schema(description = "사원 통신사")
+        Telecom telecom,
+
+        @Schema(description = "사원 생일")
+        String birthday,
+
+        @Schema(description = "사원 홈택스 정보")
+        HomeTax hometax,
+
+        @Schema(description = "사원 권한 할당 여부")
+        Boolean isSignedIn
+) {
+    public static ReadEmpResponse of(Emp emp) {
+        return new ReadEmpResponse(
+                emp.getId(),
+                emp.getEmployeeId(),
+                emp.getName(),
+                emp.getEmail(),
+                emp.getRole(),
+                emp.getPhoneNumber(),
+                emp.getTelecom(),
+                emp.getBirthday(),
+                emp.getHometax(),
+                emp.getIsSignedIn()
+        );
+    }
+}

--- a/src/main/java/com/seoulmilk/emp/dto/response/ReadEmpsResponse.java
+++ b/src/main/java/com/seoulmilk/emp/dto/response/ReadEmpsResponse.java
@@ -1,0 +1,14 @@
+package com.seoulmilk.emp.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record ReadEmpsResponse(
+        @Schema(description = "사원 목록")
+        List<FilteredEmpResponse> emps
+) {
+    public static ReadEmpsResponse of(List<FilteredEmpResponse> emps) {
+        return new ReadEmpsResponse(emps);
+    }
+}

--- a/src/main/java/com/seoulmilk/emp/dto/response/UpdateHometaxInfoResponse.java
+++ b/src/main/java/com/seoulmilk/emp/dto/response/UpdateHometaxInfoResponse.java
@@ -1,0 +1,15 @@
+package com.seoulmilk.emp.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UpdateHometaxInfoResponse(
+        @Schema(name = "성공 여부", example = "true")
+        Boolean isSuccess,
+
+        @Schema(name = "메시지", example = "홈택스 정보가 성공적으로 업데이트 되었습니다.")
+        String message
+) {
+    public static UpdateHometaxInfoResponse of(Boolean isSuccess, String message) {
+        return new UpdateHometaxInfoResponse(isSuccess, message);
+    }
+}

--- a/src/main/java/com/seoulmilk/emp/exception/AdminErrorCode.java
+++ b/src/main/java/com/seoulmilk/emp/exception/AdminErrorCode.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AdminErrorCode implements BaseErrorCode<DomainException> {
     NOT_ADMIN_EXCEPTION(HttpStatus.FORBIDDEN, "사원 권한 할당은 관리자만 가능합니다."),
-    ALREADY_ADMINISTRATOR(HttpStatus.BAD_REQUEST, "이미 관리자 권한을 가진 사원입니다.");
+    ALREADY_ADMINISTRATOR(HttpStatus.BAD_REQUEST, "이미 관리자 권한을 가진 사원입니다."),
+    EMP_NOT_FOUND(HttpStatus.NOT_FOUND, "일부 직원 PK가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/com/seoulmilk/emp/infrastructure/persistence/repository/EmpJpaRepository.java
+++ b/src/main/java/com/seoulmilk/emp/infrastructure/persistence/repository/EmpJpaRepository.java
@@ -1,7 +1,9 @@
 package com.seoulmilk.emp.infrastructure.persistence.repository;
 
-import com.seoulmilk.emp.domain.entity.Emp;
+import com.seoulmilk.emp.dto.response.FilteredEmpResponse;
 import com.seoulmilk.emp.infrastructure.persistence.jpa.entity.EmpJpaEntity;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -31,4 +33,29 @@ public interface EmpJpaRepository extends JpaRepository<EmpJpaEntity, Long> {
                 where e.id = :id
             """)
     void grantPrivilege(Long id);
+
+    List<EmpJpaEntity> findAllByIdIn(List<Long> ids);
+
+    @Query("SELECT e FROM EmpJpaEntity e ORDER BY e.id DESC")
+    List<EmpJpaEntity> findAllOrderByIdDesc(Pageable pageable);
+
+    @NotNull
+    @Query("""
+            SELECT new com.seoulmilk.emp.dto.response.FilteredEmpResponse(
+                e.id,
+                e.name,
+                e.employeeId,
+                e.role
+            )
+            FROM EmpJpaEntity e
+            """)
+    List<FilteredEmpResponse> findAllWithNeededInfo();
+
+    @Modifying
+    @Query("""
+                update EmpJpaEntity e
+                set e.hometax = :hometaxName
+                where e.id = :empPk
+            """)
+    void updateHometaxInfo(Long empPk, String hometaxName);
 }

--- a/src/main/java/com/seoulmilk/emp/infrastructure/repository/EmpRepositoryImpl.java
+++ b/src/main/java/com/seoulmilk/emp/infrastructure/repository/EmpRepositoryImpl.java
@@ -3,12 +3,14 @@ package com.seoulmilk.emp.infrastructure.repository;
 import com.seoulmilk.core.exception.error.GlobalErrorCode;
 import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.emp.domain.repository.EmpRepository;
+import com.seoulmilk.emp.dto.response.FilteredEmpResponse;
 import com.seoulmilk.emp.exception.EmpErrorCode;
 import com.seoulmilk.emp.infrastructure.mapper.EmpMapper;
 import com.seoulmilk.emp.infrastructure.persistence.jpa.entity.EmpJpaEntity;
 import com.seoulmilk.emp.infrastructure.persistence.repository.EmpJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -49,8 +51,16 @@ public class EmpRepositoryImpl implements EmpRepository {
     }
 
     @Override
-    public void deleteAll() {
-        empJpaRepository.deleteAll();
+    public void deleteAll(List<Emp> emps) {
+        try {
+            empJpaRepository.deleteAll(emps.stream()
+                    .map(empMapper::toJpaEntity)
+                    .toList()
+            );
+        } catch (Exception e) {
+            log.error("[EmpRepositoryImpl] deleteAll 쿼리 실행 중 에러 발생 : {}", e.getMessage());
+            throw GlobalErrorCode.INTERNAL_SERVER_ERROR.toException();
+        }
     }
 
     @Override
@@ -85,4 +95,36 @@ public class EmpRepositoryImpl implements EmpRepository {
             throw GlobalErrorCode.INTERNAL_SERVER_ERROR.toException();
         }
     }
+
+    @Override
+    public List<Emp> findAllByIds(List<Long> ids) {
+        List<EmpJpaEntity> empJpaEntities = empJpaRepository.findAllByIdIn(ids);
+        return empJpaEntities.stream()
+                .map(empMapper::toDomainEntity)
+                .toList();
+    }
+
+    @Override
+    public List<FilteredEmpResponse> findAllWithNeededInfo() {
+        return empJpaRepository.findAllWithNeededInfo();
+    }
+
+    @Override
+    public List<Emp> findAllOrderByIdDesc(Pageable pageable) {
+        List<EmpJpaEntity> empJpaEntities = empJpaRepository.findAllOrderByIdDesc(pageable);
+        return empJpaEntities.stream()
+                .map(empMapper::toDomainEntity)
+                .toList();
+    }
+
+    @Override
+    public void updateHometaxInfo(Long empPk, String hometaxName) {
+        try {
+            empJpaRepository.updateHometaxInfo(empPk, hometaxName);
+        } catch (Exception e) {
+            log.error("[EmpRepositoryImpl] updateHometaxInfo 쿼리 실행 중 에러 발생 : {}", e.getMessage());
+            throw GlobalErrorCode.INTERNAL_SERVER_ERROR.toException();
+        }
+    }
+
 }

--- a/src/main/java/com/seoulmilk/emp/presentation/CreateEmpController.java
+++ b/src/main/java/com/seoulmilk/emp/presentation/CreateEmpController.java
@@ -1,0 +1,33 @@
+package com.seoulmilk.emp.presentation;
+
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.core.presentation.RestResponse;
+import com.seoulmilk.emp.application.CreateEmpService;
+import com.seoulmilk.emp.dto.request.GrantPrivilegeRequest;
+import com.seoulmilk.emp.dto.response.CreateEmpResponse;
+import com.seoulmilk.emp.presentation.swagger.CreateEmpSwagger;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/admin")
+public class CreateEmpController implements CreateEmpSwagger {
+    private final CreateEmpService createEmpService;
+
+    @PostMapping
+    @RequestMapping
+    public ResponseEntity<RestResponse<CreateEmpResponse>> create(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @Valid @RequestBody GrantPrivilegeRequest createEmpRequest
+    ) {
+        CreateEmpResponse createEmpResponse = createEmpService.create(customUserDetails, createEmpRequest);
+        return ResponseEntity.ok(new RestResponse<>(createEmpResponse));
+    }
+}

--- a/src/main/java/com/seoulmilk/emp/presentation/CreateEmpController.java
+++ b/src/main/java/com/seoulmilk/emp/presentation/CreateEmpController.java
@@ -22,7 +22,6 @@ public class CreateEmpController implements CreateEmpSwagger {
     private final CreateEmpService createEmpService;
 
     @PostMapping
-    @RequestMapping
     public ResponseEntity<RestResponse<CreateEmpResponse>> create(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody GrantPrivilegeRequest createEmpRequest

--- a/src/main/java/com/seoulmilk/emp/presentation/DeleteEmpsController.java
+++ b/src/main/java/com/seoulmilk/emp/presentation/DeleteEmpsController.java
@@ -1,0 +1,34 @@
+package com.seoulmilk.emp.presentation;
+
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.core.presentation.RestResponse;
+import com.seoulmilk.emp.application.DeleteEmpService;
+import com.seoulmilk.emp.dto.request.DeleteEmpsRequest;
+import com.seoulmilk.emp.dto.response.DeleteEmpResponse;
+import com.seoulmilk.emp.presentation.swagger.DeleteEmpsSwagger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/admin")
+@RequiredArgsConstructor
+public class DeleteEmpsController implements DeleteEmpsSwagger {
+    private final DeleteEmpService deleteEmpsService;
+
+    @DeleteMapping
+    public ResponseEntity<RestResponse<DeleteEmpResponse>> delete(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody DeleteEmpsRequest deleteEmpsRequest
+    ) {
+        DeleteEmpResponse deleteEmpResponse = deleteEmpsService.delete(
+                customUserDetails,
+                deleteEmpsRequest
+        );
+        return ResponseEntity.ok(new RestResponse<>(deleteEmpResponse));
+    }
+}

--- a/src/main/java/com/seoulmilk/emp/presentation/ReadEmpController.java
+++ b/src/main/java/com/seoulmilk/emp/presentation/ReadEmpController.java
@@ -1,0 +1,39 @@
+package com.seoulmilk.emp.presentation;
+
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.core.presentation.RestResponse;
+import com.seoulmilk.emp.application.ReadEmpsService;
+import com.seoulmilk.emp.dto.response.ReadEmpResponse;
+import com.seoulmilk.emp.dto.response.ReadEmpsResponse;
+import com.seoulmilk.emp.presentation.swagger.ReadEmpSwagger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/admin")
+public class ReadEmpController implements ReadEmpSwagger {
+    private final ReadEmpsService readEmpsService;
+
+    @GetMapping("/all")
+    public ResponseEntity<RestResponse<ReadEmpsResponse>> read(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        ReadEmpsResponse readEmpsResponse = readEmpsService.read(customUserDetails);
+        return ResponseEntity.ok(new RestResponse<>(readEmpsResponse));
+    }
+
+    @GetMapping
+    public ResponseEntity<RestResponse<ReadEmpResponse>> readOneEmp(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam String name
+    ) {
+        ReadEmpResponse readEmpResponse = readEmpsService.readEmpByName(customUserDetails, name);
+        return ResponseEntity.ok(new RestResponse<>(readEmpResponse));
+    }
+}

--- a/src/main/java/com/seoulmilk/emp/presentation/UpdateValidationInfoController.java
+++ b/src/main/java/com/seoulmilk/emp/presentation/UpdateValidationInfoController.java
@@ -6,6 +6,7 @@ import com.seoulmilk.emp.application.UpdateValidationInfoService;
 import com.seoulmilk.emp.dto.request.UpdateHometaxInfoRequest;
 import com.seoulmilk.emp.dto.response.UpdateHometaxInfoResponse;
 import com.seoulmilk.emp.presentation.swagger.UpdateValidationInfoSwagger;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,7 +25,7 @@ public class UpdateValidationInfoController implements UpdateValidationInfoSwagg
     @PutMapping("/hometax")
     public ResponseEntity<RestResponse<UpdateHometaxInfoResponse>> updateHometaxInfo(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @RequestBody UpdateHometaxInfoRequest updateHometaxInfoRequest
+            @Valid @RequestBody UpdateHometaxInfoRequest updateHometaxInfoRequest
     ) {
         UpdateHometaxInfoResponse updateHometaxInfoResponse = updateValidationInfoService.updateHometaxInfo(customUserDetails, updateHometaxInfoRequest);
         return ResponseEntity.ok(new RestResponse<>(updateHometaxInfoResponse));

--- a/src/main/java/com/seoulmilk/emp/presentation/UpdateValidationInfoController.java
+++ b/src/main/java/com/seoulmilk/emp/presentation/UpdateValidationInfoController.java
@@ -1,0 +1,32 @@
+package com.seoulmilk.emp.presentation;
+
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.core.presentation.RestResponse;
+import com.seoulmilk.emp.application.UpdateValidationInfoService;
+import com.seoulmilk.emp.dto.request.UpdateHometaxInfoRequest;
+import com.seoulmilk.emp.dto.response.UpdateHometaxInfoResponse;
+import com.seoulmilk.emp.presentation.swagger.UpdateValidationInfoSwagger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/emp")
+public class UpdateValidationInfoController implements UpdateValidationInfoSwagger {
+
+    private final UpdateValidationInfoService updateValidationInfoService;
+
+    @PutMapping("/hometax")
+    public ResponseEntity<RestResponse<UpdateHometaxInfoResponse>> updateHometaxInfo(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody UpdateHometaxInfoRequest updateHometaxInfoRequest
+    ) {
+        UpdateHometaxInfoResponse updateHometaxInfoResponse = updateValidationInfoService.updateHometaxInfo(customUserDetails, updateHometaxInfoRequest);
+        return ResponseEntity.ok(new RestResponse<>(updateHometaxInfoResponse));
+    }
+}

--- a/src/main/java/com/seoulmilk/emp/presentation/swagger/CreateEmpSwagger.java
+++ b/src/main/java/com/seoulmilk/emp/presentation/swagger/CreateEmpSwagger.java
@@ -1,0 +1,25 @@
+package com.seoulmilk.emp.presentation.swagger;
+
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.core.presentation.RestResponse;
+import com.seoulmilk.emp.dto.request.GrantPrivilegeRequest;
+import com.seoulmilk.emp.dto.response.CreateEmpResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "Admin", description = "관리자")
+public interface CreateEmpSwagger {
+    @Operation(
+            summary = "사원 생성(임시) API",
+            description = "사원을 생성합니다.(임시)",
+            operationId = "/v1/admin"
+    )
+    ResponseEntity<RestResponse<CreateEmpResponse>> create(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            GrantPrivilegeRequest createEmpRequest
+    );
+}

--- a/src/main/java/com/seoulmilk/emp/presentation/swagger/DeleteEmpsSwagger.java
+++ b/src/main/java/com/seoulmilk/emp/presentation/swagger/DeleteEmpsSwagger.java
@@ -1,0 +1,29 @@
+package com.seoulmilk.emp.presentation.swagger;
+
+import com.seoulmilk.core.configuration.swagger.ApiErrorCode;
+import com.seoulmilk.core.exception.error.GlobalErrorCode;
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.core.presentation.RestResponse;
+import com.seoulmilk.emp.dto.request.DeleteEmpsRequest;
+import com.seoulmilk.emp.dto.response.DeleteEmpResponse;
+import com.seoulmilk.emp.exception.AdminErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "Admin", description = "관리자")
+public interface DeleteEmpsSwagger {
+    @Operation(
+            summary = "사원 삭제 API",
+            description = "사원을 삭제합니다.",
+            operationId = "/v1/admin"
+    )
+    @ApiErrorCode({AdminErrorCode.class, GlobalErrorCode.class})
+    ResponseEntity<RestResponse<DeleteEmpResponse>> delete(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            DeleteEmpsRequest deleteEmpsRequest
+    );
+}

--- a/src/main/java/com/seoulmilk/emp/presentation/swagger/GrantPrivilegeSwagger.java
+++ b/src/main/java/com/seoulmilk/emp/presentation/swagger/GrantPrivilegeSwagger.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Admin", description = "관리자")
 public interface GrantPrivilegeSwagger {
@@ -26,6 +25,6 @@ public interface GrantPrivilegeSwagger {
     ResponseEntity<RestResponse<GrantPrivilegeResponse>> grantPrivilege(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @RequestBody GrantPrivilegeRequest grantPrivilegeRequest
+            GrantPrivilegeRequest grantPrivilegeRequest
     );
 }

--- a/src/main/java/com/seoulmilk/emp/presentation/swagger/ReadEmpSwagger.java
+++ b/src/main/java/com/seoulmilk/emp/presentation/swagger/ReadEmpSwagger.java
@@ -1,0 +1,41 @@
+package com.seoulmilk.emp.presentation.swagger;
+
+import com.seoulmilk.core.configuration.swagger.ApiErrorCode;
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.core.presentation.RestResponse;
+import com.seoulmilk.emp.dto.response.ReadEmpResponse;
+import com.seoulmilk.emp.dto.response.ReadEmpsResponse;
+import com.seoulmilk.emp.exception.AdminErrorCode;
+import com.seoulmilk.emp.exception.EmpErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Admin", description = "관리자")
+public interface ReadEmpSwagger {
+    @Operation(
+            summary = "전체 사원 조회 API",
+            description = "전체 사원을 조회합니다.",
+            operationId = "/v1/admin/all"
+    )
+    @ApiErrorCode({AdminErrorCode.class})
+    ResponseEntity<RestResponse<ReadEmpsResponse>> read(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    );
+
+    @Operation(
+            summary = "특정 사원 조회 API",
+            description = "사원을 조회합니다.",
+            operationId = "/v1/admin"
+    )
+    @ApiErrorCode({AdminErrorCode.class, EmpErrorCode.class})
+    ResponseEntity<RestResponse<ReadEmpResponse>> readOneEmp(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam String name
+    );
+}

--- a/src/main/java/com/seoulmilk/emp/presentation/swagger/UpdateValidationInfoSwagger.java
+++ b/src/main/java/com/seoulmilk/emp/presentation/swagger/UpdateValidationInfoSwagger.java
@@ -1,0 +1,29 @@
+package com.seoulmilk.emp.presentation.swagger;
+
+import com.seoulmilk.core.configuration.swagger.ApiErrorCode;
+import com.seoulmilk.core.exception.error.GlobalErrorCode;
+import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
+import com.seoulmilk.core.presentation.RestResponse;
+import com.seoulmilk.emp.dto.request.UpdateHometaxInfoRequest;
+import com.seoulmilk.emp.dto.response.UpdateHometaxInfoResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "MyPage", description = "마이페이지")
+public interface UpdateValidationInfoSwagger {
+
+    @Operation(
+            summary = "홈택스 정보 수정 API",
+            description = "홈택스 정보를 수정합니다.",
+            operationId = "/v1/emp/hometax"
+    )
+    @ApiErrorCode({GlobalErrorCode.class})
+    ResponseEntity<RestResponse<UpdateHometaxInfoResponse>> updateHometaxInfo(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            UpdateHometaxInfoRequest updateHometaxInfoRequest
+    );
+}

--- a/src/main/java/com/seoulmilk/notice/infrastructure/persistence/repository/NoticeRepositoryImpl.java
+++ b/src/main/java/com/seoulmilk/notice/infrastructure/persistence/repository/NoticeRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.seoulmilk.notice.infrastructure.persistence.repository;
 
+import com.seoulmilk.core.exception.error.GlobalErrorCode;
 import com.seoulmilk.notice.domain.entity.Notice;
 import com.seoulmilk.notice.domain.repository.NoticeRepository;
 import com.seoulmilk.notice.dto.request.UpdateNoticeRequest;
@@ -43,7 +44,12 @@ public class NoticeRepositoryImpl implements NoticeRepository {
 
     @Override
     public void delete(Notice notice) {
-        noticeJpaRepository.delete(noticeMapper.toJpaEntity(notice));
+        try {
+            noticeJpaRepository.delete(noticeMapper.toJpaEntity(notice));
+        } catch (Exception e) {
+            log.error("[NoticeRepositoryImpl] delete 쿼리 실행 중 에러 발생 : {}", e.getMessage());
+            throw GlobalErrorCode.INTERNAL_SERVER_ERROR.toException();
+        }
     }
 
     @Override
@@ -84,8 +90,13 @@ public class NoticeRepositoryImpl implements NoticeRepository {
 
     @Override
     public void deleteAll(List<Notice> notices) {
-        noticeJpaRepository.deleteAll(notices.stream()
-                .map(noticeMapper::toJpaEntity)
-                .toList());
+        try {
+            noticeJpaRepository.deleteAll(notices.stream()
+                    .map(noticeMapper::toJpaEntity)
+                    .toList());
+        } catch (Exception e) {
+            log.error("[NoticeRepositoryImpl] deleteAll 쿼리 실행 중 에러 발생 : {}", e.getMessage());
+            throw GlobalErrorCode.INTERNAL_SERVER_ERROR.toException();
+        }
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x]  전체 직원 호출 
- [x]  유저 검색 -> 이름으로
- [x]  사원 생성은 그냥 이름 + 사번 입력하면 되도록
- [x]  반환값에 생일 추가
- [x]  간편 인증 선택 추가

---

## ✏️ 관련 이슈
- Resolves : #79 
---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 로그인 시 사용자 프로필에 생일 정보가 추가되어 더 개인화된 경험 제공
  - 홈택스 정보 수정 기능이 도입되어 관련 정보를 손쉽게 업데이트 가능
  - 관리자 전용으로 직원 목록 조회, 개별 직원 조회, 신규 생성(권한 부여 포함) 및 삭제 기능이 추가되어 직원 관리 효율성이 향상됨
  - 직원 삭제 요청을 처리하는 기능이 추가되어 여러 직원의 정보를 한 번에 삭제 가능
  - 직원 생성 시 새로운 응답 형식이 도입되어 생성된 직원의 세부 정보를 명확하게 제공
  - 직원 정보 조회 시 필터링된 응답 형식이 도입되어 필요한 정보만을 쉽게 확인 가능
  - 홈택스 정보를 업데이트할 수 있는 기능이 추가되어 직원의 세부 정보를 보다 정확하게 관리 가능
- **버그 수정**
  - 직원 삭제 시 유효하지 않은 ID에 대한 오류 처리 개선
  - 홈택스 정보 조회 시 발생할 수 있는 오류에 대한 처리 로직 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->