### PR TITLE
Feat: (#86) 로그인 반환 값에 회원가입 날짜를 보내준다.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,6 @@ services:
     networks:
       - app-network
 
-
 networks:
   app-network:
     driver: bridge

--- a/src/main/java/com/seoulmilk/auth/application/PasswordHashingService.java
+++ b/src/main/java/com/seoulmilk/auth/application/PasswordHashingService.java
@@ -6,4 +6,5 @@ import com.seoulmilk.emp.domain.value.Password;
 public interface PasswordHashingService {
     HashedPassword hash(Password password);
     void matches(String rawPassword, HashedPassword hashedPassword);
+    HashedPassword generateInitialPassword(String phoneNumber);
 }

--- a/src/main/java/com/seoulmilk/auth/infrastructure/BcryptPasswordHashingService.java
+++ b/src/main/java/com/seoulmilk/auth/infrastructure/BcryptPasswordHashingService.java
@@ -24,4 +24,8 @@ public class BcryptPasswordHashingService implements PasswordHashingService {
             throw AuthenticationErrorCode.PASSWORD_NOT_MATCH.toException();
         }
     }
+
+    public HashedPassword generateInitialPassword(String phoneNumber) {
+        return HashedPassword.of(passwordEncoder.encode(phoneNumber.substring(3)));
+    }
 }

--- a/src/main/java/com/seoulmilk/auth/presentation/dto/response/LoginResponse.java
+++ b/src/main/java/com/seoulmilk/auth/presentation/dto/response/LoginResponse.java
@@ -4,6 +4,8 @@ import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.emp.domain.value.Role;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
+
 public record LoginResponse(
         @Schema(description = "Access Token")
         String accessToken,
@@ -28,10 +30,13 @@ public record LoginResponse(
             String birthday,
 
             @Schema(description = "사용자 권한", example = "ADMIN")
-            Role role
+            Role role,
+
+            @Schema(description = "회원가입 날짜 및 시간", example = "2021-01-01T00:00:00")
+            LocalDateTime createdAt
     ) {
         public static UserInfo from(Emp employee) {
-            return new UserInfo(employee.getEmployeeId(), employee.getName(), employee.getPhoneNumber(), employee.getEmail(), employee.getBirthday(), employee.getRole());
+            return new UserInfo(employee.getEmployeeId(), employee.getName(), employee.getPhoneNumber(), employee.getEmail(), employee.getBirthday(), employee.getRole(), employee.getCreatedAt());
         }
     }
 

--- a/src/main/java/com/seoulmilk/emp/application/CreateEmpService.java
+++ b/src/main/java/com/seoulmilk/emp/application/CreateEmpService.java
@@ -41,7 +41,7 @@ public class CreateEmpService {
         );
 
         empRepository.save(createdEmp);
-        empRepository.grantPrivilege(createdEmp);
+        empRepository.grantPrivilege(createdEmp, passwordHashingService.generateInitialPassword("12345678"));
         return CreateEmpResponse.of(createdEmp);
     }
 

--- a/src/main/java/com/seoulmilk/emp/application/GrantPrivilegeService.java
+++ b/src/main/java/com/seoulmilk/emp/application/GrantPrivilegeService.java
@@ -1,8 +1,11 @@
 package com.seoulmilk.emp.application;
 
+import com.seoulmilk.auth.application.PasswordHashingService;
 import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
 import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.emp.domain.repository.EmpRepository;
+import com.seoulmilk.emp.domain.value.HashedPassword;
+import com.seoulmilk.emp.domain.value.Password;
 import com.seoulmilk.emp.domain.value.Role;
 import com.seoulmilk.emp.dto.request.GrantPrivilegeRequest;
 import com.seoulmilk.emp.dto.response.GrantPrivilegeResponse;
@@ -18,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Log4j2
 public class GrantPrivilegeService {
     private final EmpRepository empRepository;
+    private final PasswordHashingService passwordHashingService;
 
     @Transactional
     public GrantPrivilegeResponse grantPrivilege(CustomUserDetails customUserDetails, GrantPrivilegeRequest grantPrivilegeRequest) {
@@ -29,8 +33,7 @@ public class GrantPrivilegeService {
         Emp emp = empRepository.findByEmployeeName(grantPrivilegeRequest.name()).orElseThrow(EmpErrorCode.CAN_NOT_FIND_EMPLOYEE_WITH_NAME::toException);
 
         validateEmp(grantPrivilegeRequest, emp);
-
-        empRepository.grantPrivilege(emp);
+        empRepository.grantPrivilege(emp, passwordHashingService.generateInitialPassword(emp.getPhoneNumber()));
         return GrantPrivilegeResponse.of("사원 권한 할당에 성공했습니다.", emp);
     }
 

--- a/src/main/java/com/seoulmilk/emp/domain/repository/EmpRepository.java
+++ b/src/main/java/com/seoulmilk/emp/domain/repository/EmpRepository.java
@@ -1,6 +1,7 @@
 package com.seoulmilk.emp.domain.repository;
 
 import com.seoulmilk.emp.domain.entity.Emp;
+import com.seoulmilk.emp.domain.value.HashedPassword;
 import com.seoulmilk.emp.dto.response.FilteredEmpResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -22,7 +23,7 @@ public interface EmpRepository {
 
     List<Emp> findAllByName(String employeeName);
 
-    void grantPrivilege(Emp emp);
+    void grantPrivilege(Emp emp, HashedPassword hashedPassword);
 
     List<Emp> findAllByIds(List<Long> ids);
 

--- a/src/main/java/com/seoulmilk/emp/infrastructure/persistence/repository/EmpJpaRepository.java
+++ b/src/main/java/com/seoulmilk/emp/infrastructure/persistence/repository/EmpJpaRepository.java
@@ -29,10 +29,12 @@ public interface EmpJpaRepository extends JpaRepository<EmpJpaEntity, Long> {
     @Modifying
     @Query("""
                 update EmpJpaEntity e
-                set e.isSignedIn = CASE WHEN e.isSignedIn = true THEN false ELSE true END
+                set e.isSignedIn = CASE WHEN e.isSignedIn = true THEN false ELSE true END,
+                e.password = :hashedPassword
                 where e.id = :id
             """)
-    void grantPrivilege(Long id);
+    void grantPrivilege(Long id, String hashedPassword);
+
 
     List<EmpJpaEntity> findAllByIdIn(List<Long> ids);
 

--- a/src/main/java/com/seoulmilk/emp/infrastructure/repository/EmpRepositoryImpl.java
+++ b/src/main/java/com/seoulmilk/emp/infrastructure/repository/EmpRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.seoulmilk.emp.infrastructure.repository;
 import com.seoulmilk.core.exception.error.GlobalErrorCode;
 import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.emp.domain.repository.EmpRepository;
+import com.seoulmilk.emp.domain.value.HashedPassword;
 import com.seoulmilk.emp.dto.response.FilteredEmpResponse;
 import com.seoulmilk.emp.exception.EmpErrorCode;
 import com.seoulmilk.emp.infrastructure.mapper.EmpMapper;
@@ -82,14 +83,15 @@ public class EmpRepositoryImpl implements EmpRepository {
     }
 
     @Override
-    public void grantPrivilege(Emp emp) {
+    public void grantPrivilege(Emp emp, HashedPassword hashedPassword) {
         try {
             EmpJpaEntity empJpaEntity = empMapper.toJpaEntity(emp);
             if (empJpaEntity == null) {
                 log.error("[EmpRepositoryImpl] 사원 엔티티를 JPA 엔티티로 변환 도중 에러 발생 ");
                 throw EmpErrorCode.FAILED_TO_SAVE_EMPLOYEE.toException();
             }
-            empJpaRepository.grantPrivilege(empJpaEntity.getId());
+
+            empJpaRepository.grantPrivilege(empJpaEntity.getId(), hashedPassword.getValue());
         } catch (Exception e) {
             log.error("[EmpRepositoryImpl] grantPrivilege 쿼리 실행 중 에러 발생 : {}", e.getMessage());
             throw GlobalErrorCode.INTERNAL_SERVER_ERROR.toException();
@@ -126,5 +128,4 @@ public class EmpRepositoryImpl implements EmpRepository {
             throw GlobalErrorCode.INTERNAL_SERVER_ERROR.toException();
         }
     }
-
 }

--- a/src/test/java/com/seoulmilk/emp/application/GrantPrivilegeServiceTest.java
+++ b/src/test/java/com/seoulmilk/emp/application/GrantPrivilegeServiceTest.java
@@ -1,5 +1,6 @@
 package com.seoulmilk.emp.application;
 
+import com.seoulmilk.auth.application.PasswordHashingService;
 import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
 import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.emp.domain.repository.EmpRepository;
@@ -28,6 +29,9 @@ class GrantPrivilegeServiceTest {
 
     @Mock
     private CustomUserDetails adminUserDetails;
+
+    @Mock
+    private PasswordHashingService passwordHashingService;
 
     @InjectMocks
     private GrantPrivilegeService grantPrivilegeService;
@@ -58,7 +62,7 @@ class GrantPrivilegeServiceTest {
         GrantPrivilegeResponse response = grantPrivilegeService.grantPrivilege(adminUserDetails, validRequest);
 
         // Then
-        verify(empRepository, times(1)).grantPrivilege(mockEmp);
+        verify(empRepository, times(1)).grantPrivilege(mockEmp, null);
         assertThat(response.message()).isEqualTo("사원 권한 할당에 성공했습니다.");
     }
 
@@ -113,7 +117,7 @@ class GrantPrivilegeServiceTest {
         assertThatThrownBy(() -> grantPrivilegeService.grantPrivilege(adminUserDetails, invalidRequest))
                 .isInstanceOf(EmpErrorCode.INVALID_NAME_AND_EMPLOYEE_ID.toException().getClass());
 
-        verify(empRepository, never()).grantPrivilege(any());
+        verify(empRepository, never()).grantPrivilege(any(), any());
     }
 
     @Test
@@ -133,6 +137,6 @@ class GrantPrivilegeServiceTest {
         assertThatThrownBy(() -> grantPrivilegeService.grantPrivilege(adminUserDetails, validRequest))
                 .isInstanceOf(AdminErrorCode.ALREADY_ADMINISTRATOR.toException().getClass());
 
-        verify(empRepository, never()).grantPrivilege(any());
+        verify(empRepository, never()).grantPrivilege(any(), any());
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 로그인 반환 값에 회원가입 날짜를 보내준다.


---

## ✏️ 관련 이슈

- Resolves : #86 


---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 로그인 응답에 사용자 등록 일시 정보가 추가되어, 계정 생성 시 기록된 날짜와 시간을 확인할 수 있습니다. 이를 통해 로그인 시 제공되는 사용자 정보가 한층 더 상세해졌으며, 계정 관련 데이터의 신뢰성과 투명성이 향상되었습니다.
  - 초기 비밀번호를 생성할 수 있는 기능이 추가되어, 사용자 전화번호를 기반으로 해시된 비밀번호를 생성할 수 있습니다.
  - 권한 부여 시 초기 비밀번호를 함께 처리할 수 있는 기능이 추가되어, 보안성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->