### PR TITLE
Feat:(#94) 유저 삭제시 공지도 같이 삭제한다.

### DIFF
--- a/src/main/java/com/seoulmilk/auth/exception/HometaxErrorCode.java
+++ b/src/main/java/com/seoulmilk/auth/exception/HometaxErrorCode.java
@@ -1,0 +1,22 @@
+package com.seoulmilk.auth.exception;
+
+import com.seoulmilk.core.exception.DomainException;
+import com.seoulmilk.core.exception.error.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum HometaxErrorCode implements BaseErrorCode<DomainException> {
+    SAME_HOMETAX(HttpStatus.BAD_REQUEST, "동일한 홈택스로 수정할 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+        return new DomainException(httpStatus, this);
+    }
+}

--- a/src/main/java/com/seoulmilk/core/infrastructure/security/CustomUserDetails.java
+++ b/src/main/java/com/seoulmilk/core/infrastructure/security/CustomUserDetails.java
@@ -1,6 +1,7 @@
 package com.seoulmilk.core.infrastructure.security;
 
 import com.seoulmilk.emp.domain.entity.Emp;
+import com.seoulmilk.emp.domain.value.HomeTax;
 import com.seoulmilk.emp.domain.value.Role;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -58,5 +59,9 @@ public record CustomUserDetails(Emp emp) implements UserDetails {
 
     public Role getRole() {
         return emp.getRole();
+    }
+
+    public HomeTax getHomeTax() {
+        return emp.getHometax();
     }
 }

--- a/src/main/java/com/seoulmilk/emp/application/DeleteEmpService.java
+++ b/src/main/java/com/seoulmilk/emp/application/DeleteEmpService.java
@@ -7,6 +7,7 @@ import com.seoulmilk.emp.domain.value.Role;
 import com.seoulmilk.emp.dto.request.DeleteEmpsRequest;
 import com.seoulmilk.emp.dto.response.DeleteEmpResponse;
 import com.seoulmilk.emp.exception.AdminErrorCode;
+import com.seoulmilk.notice.domain.repository.NoticeRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ import java.util.List;
 public class DeleteEmpService {
 
     private final EmpRepository empRepository;
+    private final NoticeRepository noticeRepository;
 
     @Transactional
     public DeleteEmpResponse delete(
@@ -37,6 +39,7 @@ public class DeleteEmpService {
             throw AdminErrorCode.EMP_NOT_FOUND.toException();
         }
 
+        noticeRepository.deleteAllNoticesByEmps(emps);
         empRepository.deleteAll(emps);
         return DeleteEmpResponse.of(
                 true,

--- a/src/main/java/com/seoulmilk/emp/application/UpdateValidationInfoService.java
+++ b/src/main/java/com/seoulmilk/emp/application/UpdateValidationInfoService.java
@@ -1,5 +1,6 @@
 package com.seoulmilk.emp.application;
 
+import com.seoulmilk.auth.exception.HometaxErrorCode;
 import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
 import com.seoulmilk.emp.domain.repository.EmpRepository;
 import com.seoulmilk.emp.domain.value.HomeTax;
@@ -19,7 +20,10 @@ public class UpdateValidationInfoService {
             CustomUserDetails customUserDetails,
             UpdateHometaxInfoRequest updateHometaxInfoRequest
     ) {
-        String homeTax = HomeTax.valueOf(updateHometaxInfoRequest.homeTaxNum()).name();
+
+        HomeTax homeTax = HomeTax.fromValue(updateHometaxInfoRequest.homeTaxNum());
+
+        if (customUserDetails.getHomeTax() == homeTax) throw HometaxErrorCode.SAME_HOMETAX.toException();
 
         empRepository.updateHometaxInfo(
                 customUserDetails.getId(),

--- a/src/main/java/com/seoulmilk/emp/domain/repository/EmpRepository.java
+++ b/src/main/java/com/seoulmilk/emp/domain/repository/EmpRepository.java
@@ -2,6 +2,7 @@ package com.seoulmilk.emp.domain.repository;
 
 import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.emp.domain.value.HashedPassword;
+import com.seoulmilk.emp.domain.value.HomeTax;
 import com.seoulmilk.emp.dto.response.FilteredEmpResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -31,5 +32,5 @@ public interface EmpRepository {
 
     List<Emp> findAllOrderByIdDesc(Pageable pageable);
 
-    void updateHometaxInfo(Long empPk, String hometaxName);
+    void updateHometaxInfo(Long empPk, HomeTax hometaxName);
 }

--- a/src/main/java/com/seoulmilk/emp/dto/request/UpdateHometaxInfoRequest.java
+++ b/src/main/java/com/seoulmilk/emp/dto/request/UpdateHometaxInfoRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Pattern;
 public record UpdateHometaxInfoRequest(
         @NotNull(message = "홈택스 번호를 입력해주세요.")
         @Pattern(regexp = "^[1-9]$", message = "홈택스 번호는 1부터 9 사이입니다.")
-        @Schema(name = "홈택스 번호", example = "KAKAO : 1, PAYCO : 2, SAMSUMG_PASS : 3, KB_MOBILE : 4, PASS : 5, NAVER : 6, SHINHAN : 7, TOSS : 8, BANK_SALAD : 9")
+        @Schema(name = "homeTaxNum", example = "KAKAO : 1, PAYCO : 2, SAMSUMG_PASS : 3, KB_MOBILE : 4, PASS : 5, NAVER : 6, SHINHAN : 7, TOSS : 8, BANK_SALAD : 9")
         String homeTaxNum
 ) {
 }

--- a/src/main/java/com/seoulmilk/emp/infrastructure/persistence/repository/EmpJpaRepository.java
+++ b/src/main/java/com/seoulmilk/emp/infrastructure/persistence/repository/EmpJpaRepository.java
@@ -1,5 +1,6 @@
 package com.seoulmilk.emp.infrastructure.persistence.repository;
 
+import com.seoulmilk.emp.domain.value.HomeTax;
 import com.seoulmilk.emp.dto.response.FilteredEmpResponse;
 import com.seoulmilk.emp.infrastructure.persistence.jpa.entity.EmpJpaEntity;
 import org.jetbrains.annotations.NotNull;
@@ -56,8 +57,8 @@ public interface EmpJpaRepository extends JpaRepository<EmpJpaEntity, Long> {
     @Modifying
     @Query("""
                 update EmpJpaEntity e
-                set e.hometax = :hometaxName
+                set e.hometax = :homeTax
                 where e.id = :empPk
             """)
-    void updateHometaxInfo(Long empPk, String hometaxName);
+    void updateHometaxInfo(Long empPk, HomeTax homeTax);
 }

--- a/src/main/java/com/seoulmilk/emp/infrastructure/repository/EmpRepositoryImpl.java
+++ b/src/main/java/com/seoulmilk/emp/infrastructure/repository/EmpRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.seoulmilk.core.exception.error.GlobalErrorCode;
 import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.emp.domain.repository.EmpRepository;
 import com.seoulmilk.emp.domain.value.HashedPassword;
+import com.seoulmilk.emp.domain.value.HomeTax;
 import com.seoulmilk.emp.dto.response.FilteredEmpResponse;
 import com.seoulmilk.emp.exception.EmpErrorCode;
 import com.seoulmilk.emp.infrastructure.mapper.EmpMapper;
@@ -120,9 +121,9 @@ public class EmpRepositoryImpl implements EmpRepository {
     }
 
     @Override
-    public void updateHometaxInfo(Long empPk, String hometaxName) {
+    public void updateHometaxInfo(Long empPk, HomeTax homeTax) {
         try {
-            empJpaRepository.updateHometaxInfo(empPk, hometaxName);
+            empJpaRepository.updateHometaxInfo(empPk, homeTax);
         } catch (Exception e) {
             log.error("[EmpRepositoryImpl] updateHometaxInfo 쿼리 실행 중 에러 발생 : {}", e.getMessage());
             throw GlobalErrorCode.INTERNAL_SERVER_ERROR.toException();

--- a/src/main/java/com/seoulmilk/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/com/seoulmilk/notice/domain/repository/NoticeRepository.java
@@ -1,5 +1,6 @@
 package com.seoulmilk.notice.domain.repository;
 
+import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.notice.domain.entity.Notice;
 import com.seoulmilk.notice.dto.request.UpdateNoticeRequest;
 import com.seoulmilk.notice.infrastructure.persistence.jpa.entity.NoticeJpaEntity;
@@ -29,4 +30,6 @@ public interface NoticeRepository {
     List<Notice> findAllByIds(List<Long> ids);
 
     void deleteAll(List<Notice> notices);
+
+    void deleteAllNoticesByEmps(List<Emp> emps);
 }

--- a/src/main/java/com/seoulmilk/notice/infrastructure/persistence/jpa/repository/NoticeJpaRepository.java
+++ b/src/main/java/com/seoulmilk/notice/infrastructure/persistence/jpa/repository/NoticeJpaRepository.java
@@ -1,5 +1,6 @@
 package com.seoulmilk.notice.infrastructure.persistence.jpa.repository;
 
+import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.notice.dto.request.UpdateNoticeRequest;
 import com.seoulmilk.notice.infrastructure.persistence.jpa.entity.NoticeJpaEntity;
 import org.springframework.data.domain.Page;
@@ -8,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -27,4 +29,9 @@ public interface NoticeJpaRepository extends JpaRepository<NoticeJpaEntity, Long
     int update(UpdateNoticeRequest updateNoticeRequest);
 
     List<NoticeJpaEntity> findAllByIdIn(List<Long> ids);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM NoticeJpaEntity n WHERE n.authorPk IN :empPks")
+    void deleteAllByAuthorPk(@Param("empPks") List<Long> empPks);
 }
+

--- a/src/main/java/com/seoulmilk/notice/infrastructure/persistence/repository/NoticeRepositoryImpl.java
+++ b/src/main/java/com/seoulmilk/notice/infrastructure/persistence/repository/NoticeRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.seoulmilk.notice.infrastructure.persistence.repository;
 
 import com.seoulmilk.core.exception.error.GlobalErrorCode;
+import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.notice.domain.entity.Notice;
 import com.seoulmilk.notice.domain.repository.NoticeRepository;
 import com.seoulmilk.notice.dto.request.UpdateNoticeRequest;
@@ -96,6 +97,18 @@ public class NoticeRepositoryImpl implements NoticeRepository {
                     .toList());
         } catch (Exception e) {
             log.error("[NoticeRepositoryImpl] deleteAll 쿼리 실행 중 에러 발생 : {}", e.getMessage());
+            throw GlobalErrorCode.INTERNAL_SERVER_ERROR.toException();
+        }
+    }
+
+    @Override
+    public  void deleteAllNoticesByEmps(List<Emp> emps) {
+        try {
+            noticeJpaRepository.deleteAllByAuthorPk(emps.stream()
+                    .map(Emp::getId)
+                    .toList());
+        } catch (Exception e) {
+            log.error("[NoticeRepositoryImpl] deleteAllByEmps 쿼리 실행 중 에러 발생 : {}", e.getMessage());
             throw GlobalErrorCode.INTERNAL_SERVER_ERROR.toException();
         }
     }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 유저 삭제시 공지도 같이 삭제한다.

---

## ✏️ 관련 이슈

- Resolves : #94 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 직원 삭제 시, 해당 직원과 관련된 공지사항이 함께 제거되도록 기능을 추가했습니다.
	- 사용자 세부정보에서 홈택스 정보를 조회할 수 있는 기능을 추가했습니다.
- **버그 수정**
	- 동일한 홈택스 번호로 업데이트할 경우 예외를 발생시키는 검증 로직을 추가했습니다.
- **문서화**
	- API 문서에서 홈택스 번호 필드의 이름을 "homeTaxNum"으로 변경했습니다.
- **변경사항**
	- 홈택스 정보를 업데이트하는 메서드의 매개변수 타입을 `String`에서 `HomeTax`로 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->