### PR TITLE
Feat: (#98) 1년이 지난 세금 영수증 조회를 막는다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ out/
 src/main/resources/application.yml
 src/main/resources/application-local.yml
 src/test/resources/application.yml
+src/test/resources/application-test.yml
 
 ### docker-compose ###
 docker-compose-kafka.yaml

--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -7,7 +7,6 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     implementation 'org.springframework.kafka:spring-kafka'
-    testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     // Web-flux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
@@ -17,4 +16,7 @@ dependencies {
 
     // redis
     implementation "org.springframework.boot:spring-boot-starter-data-redis"
+
+    // Batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 }

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -2,6 +2,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'com.h2database:h2'
+    testImplementation 'org.springframework.batch:spring-batch-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/seoulmilk/BackendApplication.java
+++ b/src/main/java/com/seoulmilk/BackendApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @ConfigurationPropertiesScan
 @EnableFeignClients
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/seoulmilk/core/application/DailyUpdateScheduler.java
+++ b/src/main/java/com/seoulmilk/core/application/DailyUpdateScheduler.java
@@ -1,0 +1,29 @@
+package com.seoulmilk.core.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class DailyUpdateScheduler {
+    private final JobLauncher jobLauncher;
+    private final Job bulkUpdateJob;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void runBatchJob() throws Exception {
+        try {
+            jobLauncher.run(bulkUpdateJob, new JobParametersBuilder()
+                    .addLong("timestamp", System.currentTimeMillis())
+                    .toJobParameters());
+        } catch (Exception e) {
+            log.error("[runBatchJob()] 배치 작업 중 에러가 발생했습니다." + e.getLocalizedMessage());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/seoulmilk/core/configuration/batch/BatchConfiguration.java
+++ b/src/main/java/com/seoulmilk/core/configuration/batch/BatchConfiguration.java
@@ -1,0 +1,61 @@
+package com.seoulmilk.core.configuration.batch;
+
+import com.seoulmilk.receipt.domain.ValidReceiptRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
+
+import java.time.LocalDateTime;
+
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class BatchConfiguration {
+
+    private final ValidReceiptRepository validReceiptRepository;
+
+    @Bean
+    public Tasklet bulkUpdateTasklet() {
+        return (contribution, chunkContext) -> {
+            LocalDateTime cutoff = LocalDateTime.now().minusYears(1);
+            int updatedCount = validReceiptRepository.bulkUpdateExpiredReceipts(cutoff);
+            contribution.incrementWriteCount(updatedCount);
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    @Bean
+    public Step bulkUpdateStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            Tasklet bulkUpdateTasklet
+    ) {
+        return new StepBuilder("bulkUpdateStep", jobRepository)
+                .tasklet(bulkUpdateTasklet, transactionManager)
+                .transactionAttribute(
+                        new DefaultTransactionAttribute() {{
+                            setTimeout(60);
+                            setIsolationLevel(Isolation.READ_COMMITTED.value());
+                        }}
+                )
+                .build();
+    }
+
+    @Bean
+    public Job bulkUpdateJob(JobRepository jobRepository, Step bulkUpdateStep) {
+        return new JobBuilder("bulkUpdateJob", jobRepository)
+                .start(bulkUpdateStep)
+                .build();
+    }
+}

--- a/src/main/java/com/seoulmilk/receipt/domain/ValidReceiptRepository.java
+++ b/src/main/java/com/seoulmilk/receipt/domain/ValidReceiptRepository.java
@@ -5,6 +5,7 @@ import com.seoulmilk.receipt.domain.entity.ValidReceipt;
 import com.seoulmilk.receipt.dto.request.UpdateValidReceiptRequest;
 import com.seoulmilk.receipt.dto.request.ValidResponseSearchRequest;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,4 +30,6 @@ public interface ValidReceiptRepository {
     );
 
     List<ValidReceipt> findAll();
+
+    int bulkUpdateExpiredReceipts(LocalDateTime cutoff);
 }

--- a/src/main/java/com/seoulmilk/receipt/domain/entity/ValidReceipt.java
+++ b/src/main/java/com/seoulmilk/receipt/domain/entity/ValidReceipt.java
@@ -40,6 +40,8 @@ public class ValidReceipt {
 
     private String fileUrl;
 
+    private Boolean isShow;
+
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
@@ -87,6 +89,7 @@ public class ValidReceipt {
                 .erdat(validReceiptJpaEntity.getErdat())
                 .erzet(validReceiptJpaEntity.getErzet())
                 .fileUrl(validReceiptJpaEntity.getFileUrl())
+                .isShow(validReceiptJpaEntity.getIsShow())
                 .createdAt(validReceiptJpaEntity.getCreatedAt())
                 .updatedAt(validReceiptJpaEntity.getUpdatedAt())
                 .deleted(validReceiptJpaEntity.getDeleted())

--- a/src/main/java/com/seoulmilk/receipt/infrastructure/persistence/jpa/entity/ValidReceiptJpaEntity.java
+++ b/src/main/java/com/seoulmilk/receipt/infrastructure/persistence/jpa/entity/ValidReceiptJpaEntity.java
@@ -5,6 +5,7 @@ import com.seoulmilk.receipt.domain.entity.ValidReceipt;
 import com.seoulmilk.receipt.domain.value.Arap;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -46,6 +47,9 @@ public class ValidReceiptJpaEntity extends BaseLongIdEntity {
 
     @Column(length = 512)
     private String fileUrl;
+
+    @Builder.Default
+    private Boolean isShow = true;
 
     public static ValidReceiptJpaEntity toJpaEntity(ValidReceipt validReceipt) {
         return ValidReceiptJpaEntity.builder()

--- a/src/main/java/com/seoulmilk/receipt/infrastructure/persistence/jpa/repository/ValidReceiptJpaRepository.java
+++ b/src/main/java/com/seoulmilk/receipt/infrastructure/persistence/jpa/repository/ValidReceiptJpaRepository.java
@@ -1,13 +1,17 @@
 package com.seoulmilk.receipt.infrastructure.persistence.jpa.repository;
 
+import com.seoulmilk.receipt.domain.entity.ValidReceipt;
 import com.seoulmilk.receipt.dto.request.UpdateValidReceiptRequest;
 import com.seoulmilk.receipt.infrastructure.persistence.jpa.entity.ValidReceiptJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface ValidReceiptJpaRepository extends JpaRepository<ValidReceiptJpaEntity, Long>, JpaSpecificationExecutor<ValidReceiptJpaEntity> {
@@ -22,4 +26,12 @@ public interface ValidReceiptJpaRepository extends JpaRepository<ValidReceiptJpa
             "    v.erzet = :#{#updateValidReceiptRequest.erzet()} " +
             "WHERE v.id = :#{#updateValidReceiptRequest.id()}")
     int update(UpdateValidReceiptRequest updateValidReceiptRequest);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE ValidReceiptJpaEntity v SET v.isShow = false WHERE v.createdAt < :cutoff")
+    int bulkUpdateExpiredReceipts(@Param("cutoff") LocalDateTime cutoff);
+
+    @Query("SELECT v FROM ValidReceiptJpaEntity v WHERE v.isShow = true")
+    List<ValidReceiptJpaEntity> findAllByIsShowTrue();
+
 }

--- a/src/main/java/com/seoulmilk/receipt/infrastructure/repository/ValidReceiptRepositoryImpl.java
+++ b/src/main/java/com/seoulmilk/receipt/infrastructure/repository/ValidReceiptRepositoryImpl.java
@@ -16,6 +16,7 @@ import lombok.extern.log4j.Log4j2;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -120,6 +121,11 @@ public class ValidReceiptRepositoryImpl implements ValidReceiptRepository {
 
     @Override
     public List<ValidReceipt> findAll() {
-        return validReceiptJpaRepository.findAll().stream().map(ValidReceipt::toDomainEntity).toList();
+        return validReceiptJpaRepository.findAllByIsShowTrue().stream().map(ValidReceipt::toDomainEntity).toList();
+    }
+
+    @Override
+    public int bulkUpdateExpiredReceipts(LocalDateTime cutoff) {
+        return validReceiptJpaRepository.bulkUpdateExpiredReceipts(cutoff);
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 배치 작업을 통해 자정 생성된지 1년이 넘은 유효 세금계산서의 조회 여부를 업데이트함
- findAll() 사용 시 isShow가 true인 것들만 가져오도록 변경

---

## ✏️ 관련 이슈

- Resolves : #98 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 매일 자정에 자동으로 배치 작업이 실행되어 만료 항목이 업데이트됩니다.
  - 데이터 표시 기준이 개선되어 사용자에게 보다 정확한 정보가 제공됩니다.
  
- **테스트**
  - 배치 처리 및 메시징 관련 테스트 라이브러리가 추가되어 테스트 환경이 강화되었습니다.
  
- **종속성 관리 및 정리**
  - 불필요한 테스트 라이브러리를 제거하고, 필요한 배치 처리 라이브러리를 추가하여 환경 구성이 최적화되었습니다.
  - 특정 테스트 설정 파일이 버전 관리에서 제외되어 코드 관리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->