### PR TITLE
Refactor: (#114) 공지 조회에 캐시를 적용한다.

### DIFF
--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -19,4 +19,8 @@ dependencies {
 
     // Batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+    // Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 }

--- a/src/main/java/com/seoulmilk/BackendApplication.java
+++ b/src/main/java/com/seoulmilk/BackendApplication.java
@@ -3,6 +3,7 @@ package com.seoulmilk;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -12,6 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @ConfigurationPropertiesScan
 @EnableFeignClients
 @EnableScheduling
+@EnableCaching
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/seoulmilk/core/application/CacheService.java
+++ b/src/main/java/com/seoulmilk/core/application/CacheService.java
@@ -1,0 +1,32 @@
+package com.seoulmilk.core.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.data.redis.cache.RedisCache;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class CacheService {
+    private final CacheManager cacheManager;
+
+    public void checkCacheContent() {
+        Cache cache = cacheManager.getCache("notice");
+        if (cache != null) {
+            log.info("캐시 구현체: {}", cache.getClass().getName());
+            log.info("네이티브 캐시 구현체: {}", cache.getNativeCache().getClass().getName());
+
+            if (cache instanceof CaffeineCache) {
+                log.info("CaffeineCache 검색.");
+            } else if (cache instanceof RedisCache) {
+                log.info("RedisCache의 검색");
+            }
+        } else {
+            log.warn("캐시를 찾을 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/seoulmilk/core/configuration/cache/CacheConfiguration.java
+++ b/src/main/java/com/seoulmilk/core/configuration/cache/CacheConfiguration.java
@@ -1,0 +1,49 @@
+package com.seoulmilk.core.configuration.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.seoulmilk.notice.dto.response.PageNoticeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class CacheConfiguration {
+    @Bean
+    RedisCacheConfiguration redisCacheConfiguration(ObjectMapper objectMapper) {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new Jackson2JsonRedisSerializer<>(objectMapper, PageNoticeResponse.class)
+                        )).entryTtl(Duration.ofMinutes(10));
+    }
+
+    @Bean
+    public CacheManager customCacheManager(RedisConnectionFactory redisConnectionFactory, RedisCacheConfiguration redisCacheConfiguration) {
+
+        CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
+        caffeineCacheManager.setCaffeine(Caffeine.newBuilder()
+                .maximumSize(100)
+                .expireAfterWrite(Duration.ofMinutes(10)));
+
+        RedisCacheManager redisCacheManager = RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+
+        return new CustomCacheManager(caffeineCacheManager, redisCacheManager);
+    }
+}

--- a/src/main/java/com/seoulmilk/core/configuration/cache/CacheConfiguration.java
+++ b/src/main/java/com/seoulmilk/core/configuration/cache/CacheConfiguration.java
@@ -29,7 +29,7 @@ public class CacheConfiguration {
                 .serializeValuesWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(
                                 new Jackson2JsonRedisSerializer<>(objectMapper, PageNoticeResponse.class)
-                        )).entryTtl(Duration.ofMinutes(5));
+                        )).entryTtl(Duration.ofMinutes(10));
     }
 
     @Bean
@@ -38,7 +38,7 @@ public class CacheConfiguration {
         CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
         caffeineCacheManager.setCaffeine(Caffeine.newBuilder()
                 .maximumSize(100)
-                .expireAfterWrite(Duration.ofMinutes(10)));
+                .expireAfterWrite(Duration.ofMinutes(5)));
 
         RedisCacheManager redisCacheManager = RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(redisCacheConfiguration)

--- a/src/main/java/com/seoulmilk/core/configuration/cache/CacheConfiguration.java
+++ b/src/main/java/com/seoulmilk/core/configuration/cache/CacheConfiguration.java
@@ -29,7 +29,7 @@ public class CacheConfiguration {
                 .serializeValuesWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(
                                 new Jackson2JsonRedisSerializer<>(objectMapper, PageNoticeResponse.class)
-                        )).entryTtl(Duration.ofMinutes(10));
+                        )).entryTtl(Duration.ofMinutes(5));
     }
 
     @Bean

--- a/src/main/java/com/seoulmilk/core/configuration/cache/CacheKeyGeneratorConfiguration.java
+++ b/src/main/java/com/seoulmilk/core/configuration/cache/CacheKeyGeneratorConfiguration.java
@@ -1,0 +1,22 @@
+package com.seoulmilk.core.configuration.cache;
+
+import org.springframework.cache.interceptor.KeyGenerator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Pageable;
+
+
+@Configuration
+public class CacheKeyGeneratorConfiguration {
+
+    @Bean("noticePageableKeyGenerator")
+    public KeyGenerator keyGenerator() {
+        return (target, method, params) -> {
+            Pageable pageable = (Pageable) params[0];
+            return String.format("page-%d-size-%d",
+                    pageable.getPageNumber(),
+                    pageable.getPageSize()
+            );
+        };
+    }
+}

--- a/src/main/java/com/seoulmilk/core/configuration/cache/CustomCache.java
+++ b/src/main/java/com/seoulmilk/core/configuration/cache/CustomCache.java
@@ -25,7 +25,7 @@ public record CustomCache(Cache firstLevelCache, Cache secondLevelCache) impleme
                 firstLevelCache.put(key, valueWrapper.get());
             }
         }
-        return secondLevelCache.get(key);
+        return valueWrapper;
     }
 
     @Override

--- a/src/main/java/com/seoulmilk/core/configuration/cache/CustomCache.java
+++ b/src/main/java/com/seoulmilk/core/configuration/cache/CustomCache.java
@@ -1,0 +1,69 @@
+package com.seoulmilk.core.configuration.cache;
+
+import org.springframework.cache.Cache;
+
+import java.util.concurrent.Callable;
+
+public record CustomCache(Cache firstLevelCache, Cache secondLevelCache) implements Cache {
+    @Override
+    public String getName() {
+        return firstLevelCache.getName();
+    }
+
+    @Override
+    public Object getNativeCache() {
+        return firstLevelCache.getNativeCache();
+    }
+
+    @Override
+    public ValueWrapper get(Object key) {
+        ValueWrapper valueWrapper = firstLevelCache.get(key);
+
+        if (valueWrapper == null) {
+            valueWrapper = secondLevelCache.get(key);
+            if (valueWrapper != null) {
+                firstLevelCache.put(key, valueWrapper.get());
+            }
+        }
+        return secondLevelCache.get(key);
+    }
+
+    @Override
+    public <T> T get(Object key, Class<T> type) {
+        T value = firstLevelCache.get(key, type);
+        if (value == null) {
+            value = secondLevelCache.get(key, type);
+            if (value != null) {
+                firstLevelCache.put(key, value);
+            }
+        }
+        return value;
+    }
+
+    @Override
+    public <T> T get(Object key, Callable<T> valueLoader) {
+        try {
+            return firstLevelCache.get(key, valueLoader);
+        } catch (Exception e) {
+            return secondLevelCache.get(key, valueLoader);
+        }
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+        firstLevelCache.put(key, value);
+        secondLevelCache.put(key, value);
+    }
+
+    @Override
+    public void evict(Object key) {
+        firstLevelCache.evict(key);
+        secondLevelCache.evict(key);
+    }
+
+    @Override
+    public void clear() {
+        firstLevelCache.clear();
+        secondLevelCache.clear();
+    }
+}

--- a/src/main/java/com/seoulmilk/core/configuration/cache/CustomCacheManager.java
+++ b/src/main/java/com/seoulmilk/core/configuration/cache/CustomCacheManager.java
@@ -6,6 +6,8 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -28,6 +30,8 @@ public class CustomCacheManager implements CacheManager {
 
     @Override
     public Collection<String> getCacheNames() {
-        return caffeineCacheManager.getCacheNames();
+            Set<String> mergedNames = new HashSet<>(caffeineCacheManager.getCacheNames());
+            mergedNames.addAll(redisCacheManager.getCacheNames());
+            return mergedNames;
     }
 }

--- a/src/main/java/com/seoulmilk/core/configuration/cache/CustomCacheManager.java
+++ b/src/main/java/com/seoulmilk/core/configuration/cache/CustomCacheManager.java
@@ -1,0 +1,33 @@
+package com.seoulmilk.core.configuration.cache;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import java.util.Collection;
+
+@Getter
+@Setter
+public class CustomCacheManager implements CacheManager {
+
+    private CacheManager caffeineCacheManager;
+    private CacheManager redisCacheManager;
+
+    public CustomCacheManager(CacheManager caffeineCacheManager, CacheManager redisCacheManager) {
+        this.caffeineCacheManager = caffeineCacheManager;
+        this.redisCacheManager = redisCacheManager;
+    }
+
+    @Override
+    public Cache getCache(String name) {
+        Cache caffeineCache = caffeineCacheManager.getCache(name);
+        Cache redisCache = redisCacheManager.getCache(name);
+        return new CustomCache(caffeineCache, redisCache);
+    }
+
+    @Override
+    public Collection<String> getCacheNames() {
+        return caffeineCacheManager.getCacheNames();
+    }
+}

--- a/src/main/java/com/seoulmilk/core/configuration/redis/RedisConfig.java
+++ b/src/main/java/com/seoulmilk/core/configuration/redis/RedisConfig.java
@@ -19,7 +19,7 @@ public class RedisConfig {
 
     @Value("${spring.data.redis.host}")
     private String redisHost;
-    @Value("${spring.data.redis.port} ")
+    @Value("${spring.data.redis.port}")
     private int redisPort;
 
     @Bean

--- a/src/main/java/com/seoulmilk/core/configuration/redis/RedisConfig.java
+++ b/src/main/java/com/seoulmilk/core/configuration/redis/RedisConfig.java
@@ -9,7 +9,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
@@ -20,7 +19,7 @@ public class RedisConfig {
 
     @Value("${spring.data.redis.host}")
     private String redisHost;
-    @Value("${spring.data.redis.port}")
+    @Value("${spring.data.redis.port} ")
     private int redisPort;
 
     @Bean
@@ -44,7 +43,10 @@ public class RedisConfig {
                 JsonTypeInfo.As.PROPERTY
         );
 
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        GenericJackson2JsonRedisSerializer jsonRedisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+        template.setValueSerializer(jsonRedisSerializer);
+        template.setHashValueSerializer(jsonRedisSerializer);
+
         return template;
     }
 }

--- a/src/main/java/com/seoulmilk/notice/application/PostNoticeService.java
+++ b/src/main/java/com/seoulmilk/notice/application/PostNoticeService.java
@@ -3,14 +3,19 @@ package com.seoulmilk.notice.application;
 import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
 import com.seoulmilk.core.util.fileUtil.FileUtil;
 import com.seoulmilk.notice.domain.entity.Notice;
+import com.seoulmilk.notice.domain.event.PostNoticeEvent;
+import com.seoulmilk.notice.domain.event.PostNoticeEventPublisher;
 import com.seoulmilk.notice.domain.repository.NoticeRepository;
 import com.seoulmilk.notice.dto.request.PostNoticeRequest;
 import com.seoulmilk.notice.dto.response.PostNoticeResponse;
 import com.seoulmilk.notice.exception.NoticeErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -19,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class PostNoticeService {
 
     private final NoticeRepository noticeRepository;
+    private final PostNoticeEventPublisher postNoticeEventPublisher;
     private final FileUtil fileUtil;
 
     @Transactional
@@ -28,11 +34,21 @@ public class PostNoticeService {
             Notice notice = noticeRepository.save(
                     Notice.create(customUserDetails.getId(), customUserDetails.getUsername(), postNoticeRequest.title(), postNoticeRequest.content(), fileUrl)
             );
-
+            postNoticeEventPublisher.publishPostNoticeEvent();
             return PostNoticeResponse.create(notice);
         } catch (Exception e) {
             log.error("[PostNoticeService.post] 공지사항을 등록하는데 실패했습니다. {}", e.getMessage());
             throw NoticeErrorCode.POST_NOTICE_FAILED.toException();
         }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @CacheEvict(
+            value = "notice",
+            cacheManager = "customCacheManager",
+            allEntries = true
+    )
+    public void evictNoticePageableCache(PostNoticeEvent postNoticeEvent) {
+        log.info("[PostNoticeService.evictNoticePageableCache] 공지사항 페이지 캐시를 삭제합니다.");
     }
 }

--- a/src/main/java/com/seoulmilk/notice/application/ReadNoticeService.java
+++ b/src/main/java/com/seoulmilk/notice/application/ReadNoticeService.java
@@ -1,5 +1,6 @@
 package com.seoulmilk.notice.application;
 
+import com.seoulmilk.core.application.CacheService;
 import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.emp.domain.repository.EmpRepository;
 import com.seoulmilk.emp.exception.EmpErrorCode;
@@ -15,20 +16,25 @@ import com.seoulmilk.notice.exception.NoticeErrorCode;
 import com.seoulmilk.notice.infrastructure.persistence.jpa.entity.NoticeJpaEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReadNoticeService {
     private final NoticeRepository noticeRepository;
     private final EmpRepository empRepository;
+    private final CacheService cacheService;
 
     @Value("${spring.url.base}")
     private String baseUrl;
@@ -50,9 +56,15 @@ public class ReadNoticeService {
         return ReadNoticeResponse.create(notice, author);
     }
 
+    @Cacheable(
+            value = "notice",
+            cacheManager = "customCacheManager",
+            keyGenerator = "noticePageableKeyGenerator"
+    )
     public PageNoticeResponse<NoticeSummaryResponse> getNoticesByPage(Pageable pageable) {
+        cacheService.checkCacheContent();
+        log.info("[ReadNoticeService.getNoticesByPage] 공지사항 페이지를 조회합니다.");
         Page<Notice> notices = noticeRepository.findAllOrderByIdDesc(pageable);
-
         List<NoticeSummaryResponse> content = notices.getContent().stream()
                 .map(NoticeSummaryResponse::create).toList();
 

--- a/src/main/java/com/seoulmilk/notice/application/ReadNoticeService.java
+++ b/src/main/java/com/seoulmilk/notice/application/ReadNoticeService.java
@@ -21,7 +21,6 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/seoulmilk/notice/domain/event/PostNoticeEvent.java
+++ b/src/main/java/com/seoulmilk/notice/domain/event/PostNoticeEvent.java
@@ -1,0 +1,9 @@
+package com.seoulmilk.notice.domain.event;
+
+import org.springframework.context.ApplicationEvent;
+
+public class PostNoticeEvent extends ApplicationEvent {
+    public PostNoticeEvent(Object source) {
+        super(source);
+    }
+}

--- a/src/main/java/com/seoulmilk/notice/domain/event/PostNoticeEventPublisher.java
+++ b/src/main/java/com/seoulmilk/notice/domain/event/PostNoticeEventPublisher.java
@@ -1,0 +1,15 @@
+package com.seoulmilk.notice.domain.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostNoticeEventPublisher {
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public void publishPostNoticeEvent() {
+        applicationEventPublisher.publishEvent(new PostNoticeEvent(this));
+    }
+}

--- a/src/main/java/com/seoulmilk/notice/dto/response/PageNoticeResponse.java
+++ b/src/main/java/com/seoulmilk/notice/dto/response/PageNoticeResponse.java
@@ -4,6 +4,7 @@ import com.seoulmilk.notice.domain.entity.Notice;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.data.domain.Page;
 
+import java.io.Serializable;
 import java.util.List;
 
 public record PageNoticeResponse<T>(
@@ -24,7 +25,7 @@ public record PageNoticeResponse<T>(
 
         @Schema(description = "마지막 페이지 여부", example = "false")
         boolean last
-) {
+) implements Serializable {
     public static <T> PageNoticeResponse<T> create(List<T> content, Page<Notice> notices) {
         return new PageNoticeResponse<>(content,
                 notices.getNumber(),

--- a/src/test/java/com/seoulmilk/notice/application/PostNoticeServiceTest.java
+++ b/src/test/java/com/seoulmilk/notice/application/PostNoticeServiceTest.java
@@ -3,6 +3,7 @@ package com.seoulmilk.notice.application;
 import com.seoulmilk.core.infrastructure.security.CustomUserDetails;
 import com.seoulmilk.core.util.fileUtil.FileUtil;
 import com.seoulmilk.notice.domain.entity.Notice;
+import com.seoulmilk.notice.domain.event.PostNoticeEventPublisher;
 import com.seoulmilk.notice.domain.repository.NoticeRepository;
 import com.seoulmilk.notice.dto.request.PostNoticeRequest;
 import com.seoulmilk.notice.dto.response.PostNoticeResponse;
@@ -26,6 +27,9 @@ import static org.mockito.Mockito.*;
 public class PostNoticeServiceTest {
     @Mock
     private NoticeRepository noticeRepository;
+
+    @Mock
+    private PostNoticeEventPublisher postNoticeEventPublisher;
 
     @Mock
     private FileUtil fileUtil;

--- a/src/test/java/com/seoulmilk/notice/application/ReadNoticeServiceTest.java
+++ b/src/test/java/com/seoulmilk/notice/application/ReadNoticeServiceTest.java
@@ -1,5 +1,6 @@
 package com.seoulmilk.notice.application;
 
+import com.seoulmilk.core.application.CacheService;
 import com.seoulmilk.emp.domain.entity.Emp;
 import com.seoulmilk.emp.domain.repository.EmpRepository;
 import com.seoulmilk.emp.exception.EmpErrorCode;
@@ -39,6 +40,9 @@ class ReadNoticeServiceTest {
 
     @Mock
     private EmpRepository empRepository;
+
+    @Mock
+    private CacheService cacheService;
 
     @InjectMocks
     private ReadNoticeService readNoticeService;


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 공지 조회 작업에 2계층 캐시 구현
  - 로컬 캐시로 caffeine 사용
  - 분산 캐시로 Redis 사용
- 공지 업로드 시 캐시 Evict

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/a34a7320-bb39-4b67-b7cd-4c516d7eb24d" />


---

## ✏️ 관련 이슈

- Resolves : #114 


---

## 🎸 기타 사항 or 추가 코멘트
- Evict 전략은 발표 이후 수정 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 캐싱 시스템이 대폭 강화되어 인메모리와 분산 캐시(Redis)를 통합, 데이터 조회 속도와 안정성이 향상되었습니다.
  - 게시글(공지사항) 작성 후 이벤트 기반 캐시 갱신으로 최신 정보를 신속하게 반영합니다.
  - 새로운 캐시 관리 서비스가 추가되어 캐시 내용을 확인하고 관리할 수 있는 기능이 제공됩니다.
  - 캐시 키 생성 및 사용자 정의 캐시 관리 기능이 추가되었습니다.
  - 공지사항 조회 기능에 캐싱이 통합되어 성능이 개선되었습니다.
  - 새로운 이벤트 게시 기능이 추가되어 게시글 작성 후 이벤트를 발행합니다.

- **버그 수정**
  - Redis 설정에서 불필요한 코드가 정리되고 직렬화 설정이 개선되었습니다.

- **테스트**
  - 캐싱 및 이벤트 관련 기능을 지원하기 위해 테스트 환경이 개선되고, 관련 모의 객체가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->